### PR TITLE
feat: add Asset Core construct and pre-deploy asset verification

### DIFF
--- a/docs/concepts/asset.md
+++ b/docs/concepts/asset.md
@@ -1,0 +1,197 @@
+# Asset
+
+An **Asset** is any local file or directory bundled into the [cloud assembly](cloud-assembly.md) at synth time. Resources reference the staged asset by its absolute path on disk — a plain string known at construction time, with no token resolution required.
+
+Typical use cases:
+
+- A `cloud-init.yaml` passed to a server's `userData` field
+- A directory of provisioning scripts mounted into a VM
+- A TLS certificate bundle uploaded to a load balancer
+
+## How it works
+
+`Asset` is a `Construct` with two phases:
+
+1. **Construction time** — hashes the source content (SHA-256), resolves the destination path inside the assembly outdir, and exposes `assetHash` + `absolutePath`.
+2. **Synthesis time** — `App.synth()` (Phase 0, before stack synthesis) copies the source into `cdkx.out/assets/asset.<hash>/` and registers a `cdkx:asset` artifact in `manifest.json`.
+
+The hash is content-addressed: identical content always produces the same `asset.<hash>` directory, regardless of source path or file name. Re-running `synth` with unchanged sources is idempotent.
+
+## Basic usage
+
+```typescript title="src/main.ts" linenums="1"
+import * as path from 'node:path';
+import { App, Asset, Stack } from '@cdk-x/core';
+import { MltInstance } from '@cdk-x/multipass';
+
+const app = new App();
+const stack = new Stack(app, 'Network');
+
+const cloudInit = new Asset(stack, 'CloudInit', { // (1)!
+  path: path.resolve(__dirname, '../cloud-init.yaml'),
+});
+
+new MltInstance(stack, 'Instance', {
+  name: 'my-vm',
+  image: 'jammy',
+  cpus: 1,
+  memory: '1G',
+  cloudInit: cloudInit.absolutePath, // (2)!
+});
+
+app.synth();
+```
+
+1. The asset is a child of the stack — its lifetime follows the stack's. `path` must resolve to an existing local file.
+2. `absolutePath` is a plain `string`, not a token. The L1 construct receives it directly.
+
+## File vs directory assets
+
+`AssetProps` accepts **exactly one** of `path` or `directoryPath`:
+
+=== "File asset"
+
+    ```typescript
+    new Asset(stack, 'CloudInit', { path: './cloud-init.yaml' });
+    ```
+
+    Staged as `cdkx.out/assets/asset.<hash>/cloud-init.yaml`.
+    `absolutePath` points to the file itself.
+
+=== "Directory asset"
+
+    ```typescript
+    new Asset(stack, 'Provisioning', { directoryPath: './provisioning' });
+    ```
+
+    Staged as `cdkx.out/assets/asset.<hash>/` mirroring the source tree.
+    `absolutePath` points to the directory root (no wrapping file name).
+
+Passing both — or neither — throws at construction time.
+
+## Hashing
+
+| Source | Hash input |
+|--------|------------|
+| File   | SHA-256 of raw file bytes |
+| Directory | SHA-256 over each file's relative POSIX path + SHA-256 of its contents, joined with `\0` and `\n`, in sort order |
+
+Notes:
+
+- File **permissions** and **timestamps** are not part of the hash.
+- **Symlinks** are followed; their target contents contribute to the hash.
+- An **empty directory** still produces a stable hash.
+- Renaming a file changes the directory hash; editing the byte content of any file changes both the file and directory hash.
+
+## Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `assetHash` | `string` | SHA-256 hex digest of the source content. |
+| `absolutePath` | `string` | Absolute path to the staged file or directory inside the cloud assembly. Use this in resource properties. |
+| `sourcePath` | `string` | Absolute path to the original source on disk. |
+| `fileName` | `string \| undefined` | Source file name (file packaging). `undefined` for directory packaging. |
+| `packaging` | `'file' \| 'directory'` | Discriminator. |
+
+```typescript
+const asset = new Asset(stack, 'X', { path: './data.bin' });
+
+asset.assetHash;     // 'a3f5...'  (64 hex chars)
+asset.absolutePath;  // '/abs/cdkx.out/assets/asset.a3f5.../data.bin'
+asset.sourcePath;    // '/abs/data.bin'
+asset.fileName;      // 'data.bin'
+asset.packaging;     // 'file'
+
+Asset.isAsset(asset); // true
+```
+
+## What gets written
+
+After `cdkx synth`:
+
+```
+cdkx.out/
+├── manifest.json
+├── Network.json
+└── assets/
+    └── asset.a3f5b1c4…/
+        └── cloud-init.yaml
+```
+
+The corresponding manifest entry:
+
+```json title="cdkx.out/manifest.json"
+{
+  "version": "1.0.0",
+  "artifacts": {
+    "asset.a3f5b1c4…": {
+      "type": "cdkx:asset",
+      "properties": {
+        "hash": "a3f5b1c4…",
+        "path": "assets/asset.a3f5b1c4…/cloud-init.yaml",
+        "packaging": "file"
+      }
+    },
+    "Network": {
+      "type": "cdkx:stack",
+      "properties": { "templateFile": "Network.json" }
+    }
+  }
+}
+```
+
+The `path` field is **relative to the assembly outdir** so the assembly stays portable across machines.
+
+## Deploy-time verification
+
+Before any provider call, `cdkx deploy` runs a pre-deploy check that walks every `cdkx:asset` artifact and asserts the referenced file exists on disk. If any asset is missing, deployment fails fast with a clear error:
+
+```
+Cannot deploy: 1 asset file(s) missing from the cloud assembly.
+Run 'cdkx synth' to regenerate the assembly. Missing:
+  - /abs/cdkx.out/assets/asset.a3f5b1c4…/cloud-init.yaml
+```
+
+This catches stale or partially deleted assemblies before any remote state is mutated.
+
+## Patterns
+
+### Same content, multiple references
+
+Two `Asset` constructs over the same content produce the same hash and stage to the same directory. Both `absolutePath` strings will be equal:
+
+```typescript
+const a = new Asset(stack, 'A', { path: './cloud-init.yaml' });
+const b = new Asset(stack, 'B', { path: './cloud-init.yaml' });
+
+a.absolutePath === b.absolutePath; // true
+```
+
+### Sharing across stacks
+
+An asset can live in any stack. Other stacks may reference its `absolutePath` directly — the value is a plain string, not a token, so no cross-stack reference plumbing is needed.
+
+```typescript
+const sharedStack = new Stack(app, 'Shared');
+const ssh = new Asset(sharedStack, 'SshKey', { path: './id_ed25519.pub' });
+
+const computeStack = new Stack(app, 'Compute');
+new HtzServer(computeStack, 'Server', {
+  // ...
+  userData: ssh.absolutePath,
+});
+```
+
+## Caveats
+
+- Source paths are resolved **at construction time**, against the current working directory. Prefer `path.resolve(__dirname, …)` for portability.
+- The source file/directory must exist when the construct is created — hashing reads it eagerly.
+- Hashing is synchronous and reads the full content into memory. Very large assets will block the synth process.
+- Symlinks inside directory assets are followed; cycles will recurse.
+
+---
+
+!!! info "See also"
+    - [App](app.md) — Phase 0 of `app.synth()` is what stages assets
+    - [Cloud Assembly](cloud-assembly.md) — the `cdkx:asset` artifact format
+    - [Deployment Lifecycle](deployment-lifecycle.md) — when the pre-deploy asset check runs

--- a/e2e/multipass/cloud-init.yaml
+++ b/e2e/multipass/cloud-init.yaml
@@ -1,0 +1,8 @@
+#cloud-config
+package_update: true
+package_upgrade: true
+packages:
+  - curl
+  - htop
+runcmd:
+  - echo "cdkx multipass e2e asset provisioned $(date -u)" > /etc/cdkx-e2e.txt

--- a/e2e/multipass/src/main.ts
+++ b/e2e/multipass/src/main.ts
@@ -1,10 +1,21 @@
 import * as path from 'path';
-import { App, Stack, StackOutput } from '@cdk-x/core';
+import { App, Asset, Stack, StackOutput } from '@cdk-x/core';
 import { MltInstance } from '@cdk-x/multipass';
 
 const app = new App();
 
 const stack = new Stack(app, 'Network');
+
+const cloudInit = new Asset(stack, 'CloudInit', {
+  path: path.resolve(__dirname, '../cloud-init.yaml'),
+});
+
+// Directory asset: stages the full `cloud-init/` folder under
+// `cdkx.out/assets/asset.<hash>/`. Kept alongside the file asset above to
+// exercise the directory-packaging path end-to-end.
+new Asset(stack, 'CloudInitDir', {
+  directoryPath: path.resolve(__dirname, '../cloud-init'),
+});
 
 const instance = new MltInstance(stack, 'Instance', {
   name: 'cdk-x-multipass-e2e',
@@ -12,7 +23,10 @@ const instance = new MltInstance(stack, 'Instance', {
   cpus: 1,
   memory: '1G',
   networks: [{ name: 'en0', mode: 'auto' }],
-  mounts: [{ source: path.resolve(__dirname, '../cdkx.out'), target: '/cdkx.out' }],
+  mounts: [
+    { source: path.resolve(__dirname, '../cdkx.out'), target: '/cdkx.out' },
+  ],
+  cloudInit: cloudInit.absolutePath,
 });
 
 new StackOutput(stack, 'InstanceName', {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -118,6 +118,7 @@ nav:
       - Stack: concepts/stack.md
       - Construct: concepts/construct.md
       - Cloud Assembly: concepts/cloud-assembly.md
+      - Asset: concepts/asset.md
       - Tokens & Cross-stack References: concepts/tokens.md
       - Cloud Resource Name (CRN): concepts/crn.md
       - Deployment Lifecycle: concepts/deployment-lifecycle.md

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,6 +14,9 @@ export * from './lib/provider';
 // Assembly: CloudAssembly, CloudAssemblyBuilder, manifest types
 export * from './lib/assembly';
 
+// Asset: local-file assets staged into the cloud assembly
+export * from './lib/asset';
+
 // Synthesizer: ISynthesisSession, IStackSynthesizer, JsonSynthesizer
 export * from './lib/synthesizer';
 

--- a/packages/core/src/lib/app/app.spec.ts
+++ b/packages/core/src/lib/app/app.spec.ts
@@ -1,6 +1,10 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import { Construct } from 'constructs';
 import { App } from './app';
 import { Stack } from '../stack/stack';
+import { Asset } from '../asset/asset';
 import {
   IStackSynthesizer,
   ISynthesisSession,
@@ -192,6 +196,191 @@ describe('App', () => {
       });
       app.synth();
       expect(capturedSessions[0].outdir).toBe('/tmp/test-outdir-app');
+    });
+
+    describe('asset synthesis (Phase 0)', () => {
+      function tmpFile(name: string, contents: string): string {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cdkx-app-asset-'));
+        const filePath = path.join(dir, name);
+        fs.writeFileSync(filePath, contents, 'utf-8');
+        return filePath;
+      }
+
+      it('stages assets and registers cdkx:asset artifacts before stack synthesis', () => {
+        const outdir = fs.mkdtempSync(
+          path.join(os.tmpdir(), 'cdkx-app-synth-'),
+        );
+        const app = new App({ outdir });
+        const stack = new Stack(app, 'S');
+        const sourcePath = tmpFile('cloud-init.yaml', 'users: []');
+        const asset = new Asset(stack, 'CloudInit', { path: sourcePath });
+
+        const assembly = app.synth();
+
+        const stagedFile = path.join(
+          outdir,
+          'assets',
+          `asset.${asset.assetHash}`,
+          'cloud-init.yaml',
+        );
+        expect(fs.existsSync(stagedFile)).toBe(true);
+
+        const artifactId = `asset.${asset.assetHash}`;
+        expect(assembly.manifest.artifacts[artifactId]).toEqual({
+          type: 'cdkx:asset',
+          properties: {
+            hash: asset.assetHash,
+            path: `assets/asset.${asset.assetHash}/cloud-init.yaml`,
+            packaging: 'file',
+          },
+        });
+      });
+
+      it('collects assets nested beneath a Stack, not only direct children', () => {
+        const outdir = fs.mkdtempSync(
+          path.join(os.tmpdir(), 'cdkx-app-nested-'),
+        );
+        const app = new App({ outdir });
+        const stack = new Stack(app, 'S');
+        const l1 = new Construct(stack, 'L1');
+        const sourcePath = tmpFile('data.txt', 'nested');
+        const asset = new Asset(l1, 'Nested', { path: sourcePath });
+
+        app.synth();
+
+        const stagedFile = path.join(
+          outdir,
+          'assets',
+          `asset.${asset.assetHash}`,
+          'data.txt',
+        );
+        expect(fs.existsSync(stagedFile)).toBe(true);
+      });
+
+      it('stages assets before stack synthesizers run (assets visible on disk during stack synth)', () => {
+        const outdir = fs.mkdtempSync(
+          path.join(os.tmpdir(), 'cdkx-app-order-'),
+        );
+        const app = new App({ outdir });
+        const sourcePath = tmpFile('f.yaml', 'x');
+        const asset = new Asset(new Stack(app, 'AssetStack'), 'A', {
+          path: sourcePath,
+        });
+
+        let stagedDuringStackSynth = false;
+        const observingSynth: IStackSynthesizer = {
+          bind: () => undefined,
+          synthesize: (session) => {
+            const expectedDir = path.join(
+              session.outdir,
+              'assets',
+              `asset.${asset.assetHash}`,
+            );
+            stagedDuringStackSynth = fs.existsSync(expectedDir);
+            session.assembly.addArtifact({
+              id: 'ObservingStack',
+              templateFile: 'ObservingStack.json',
+            });
+            session.assembly.writeFile('ObservingStack.json', '{}');
+          },
+        };
+        new Stack(app, 'ObservingStack', { synthesizer: observingSynth });
+
+        app.synth();
+
+        expect(stagedDuringStackSynth).toBe(true);
+      });
+
+      it('stages directory assets: mirrors the tree and registers packaging:"directory"', () => {
+        const outdir = fs.mkdtempSync(
+          path.join(os.tmpdir(), 'cdkx-app-dir-synth-'),
+        );
+        const app = new App({ outdir });
+        const stack = new Stack(app, 'S');
+
+        const sourceDir = fs.mkdtempSync(
+          path.join(os.tmpdir(), 'cdkx-app-dir-src-'),
+        );
+        fs.writeFileSync(path.join(sourceDir, 'top.txt'), 'top', 'utf-8');
+        fs.mkdirSync(path.join(sourceDir, 'inner'));
+        fs.writeFileSync(path.join(sourceDir, 'inner', 'x.txt'), 'x', 'utf-8');
+
+        const asset = new Asset(stack, 'Role', { directoryPath: sourceDir });
+
+        const assembly = app.synth();
+
+        const stagedDir = path.join(
+          outdir,
+          'assets',
+          `asset.${asset.assetHash}`,
+        );
+        expect(fs.readFileSync(path.join(stagedDir, 'top.txt'), 'utf-8')).toBe(
+          'top',
+        );
+        expect(
+          fs.readFileSync(path.join(stagedDir, 'inner', 'x.txt'), 'utf-8'),
+        ).toBe('x');
+
+        const artifactId = `asset.${asset.assetHash}`;
+        expect(assembly.manifest.artifacts[artifactId]).toEqual({
+          type: 'cdkx:asset',
+          properties: {
+            hash: asset.assetHash,
+            path: `assets/asset.${asset.assetHash}`,
+            packaging: 'directory',
+          },
+        });
+      });
+
+      it('deduplicates directory assets with identical content into a single artifact', () => {
+        const outdir = fs.mkdtempSync(
+          path.join(os.tmpdir(), 'cdkx-app-dir-dedup-'),
+        );
+        const app = new App({ outdir });
+        const stack = new Stack(app, 'S');
+
+        const sourceA = fs.mkdtempSync(
+          path.join(os.tmpdir(), 'cdkx-app-dir-a-'),
+        );
+        fs.writeFileSync(path.join(sourceA, 'same.txt'), 'payload', 'utf-8');
+        const sourceB = fs.mkdtempSync(
+          path.join(os.tmpdir(), 'cdkx-app-dir-b-'),
+        );
+        fs.writeFileSync(path.join(sourceB, 'same.txt'), 'payload', 'utf-8');
+
+        const assetA = new Asset(stack, 'A', { directoryPath: sourceA });
+        const assetB = new Asset(stack, 'B', { directoryPath: sourceB });
+
+        const assembly = app.synth();
+
+        expect(assetA.assetHash).toBe(assetB.assetHash);
+        const assetArtifactCount = Object.values(
+          assembly.manifest.artifacts,
+        ).filter((a) => a.type === 'cdkx:asset').length;
+        expect(assetArtifactCount).toBe(1);
+      });
+
+      it('deduplicates assets with the same hash into a single artifact', () => {
+        const outdir = fs.mkdtempSync(
+          path.join(os.tmpdir(), 'cdkx-app-dedup-'),
+        );
+        const app = new App({ outdir });
+        const stack = new Stack(app, 'S');
+        const sourceA = tmpFile('a.txt', 'same');
+        const sourceB = tmpFile('a.txt', 'same');
+        const assetA = new Asset(stack, 'A', { path: sourceA });
+        new Asset(stack, 'B', { path: sourceB });
+
+        const assembly = app.synth();
+
+        expect(assetA.assetHash).toBeDefined();
+        const artifactId = `asset.${assetA.assetHash}`;
+        expect(assembly.manifest.artifacts[artifactId]).toBeDefined();
+        const assetArtifactCount = Object.values(
+          assembly.manifest.artifacts,
+        ).filter((a) => a.type === 'cdkx:asset').length;
+        expect(assetArtifactCount).toBe(1);
+      });
     });
   });
 });

--- a/packages/core/src/lib/app/app.ts
+++ b/packages/core/src/lib/app/app.ts
@@ -9,6 +9,7 @@ import {
 } from '../assembly/cloud-assembly';
 import { ISynthesisSession } from '../synthesizer/synthesizer';
 import { CycleDetector, CycleError } from '../synthesizer/cycle-detector';
+import { Asset } from '../asset/asset';
 
 export interface AppProps {
   /**
@@ -150,10 +151,32 @@ export class App extends Construct {
       assembly: builder,
     };
 
+    // Phase 0: collect and stage all assets before any stack is synthesized
+    // so that stack synthesizers can rely on asset artifacts being registered
+    // in the manifest builder.
+    this.synthesizeAssets(stacks, session);
+
     for (const stack of stacks) {
       stack.synthesizer.synthesize(session);
     }
 
     return builder.buildAssembly();
+  }
+
+  /**
+   * Walks every stack, collects descendant `Asset` instances, and stages each
+   * one exactly once (deduplicated by hash). Called at the start of `synth()`
+   * before any stack synthesizer runs.
+   */
+  private synthesizeAssets(stacks: Stack[], session: ISynthesisSession): void {
+    const seen = new Set<string>();
+    for (const stack of stacks) {
+      for (const node of stack.node.findAll()) {
+        if (!Asset.isAsset(node)) continue;
+        if (seen.has(node.assetHash)) continue;
+        seen.add(node.assetHash);
+        node.synthesizeAsset(session);
+      }
+    }
   }
 }

--- a/packages/core/src/lib/assembly/cloud-assembly.spec.ts
+++ b/packages/core/src/lib/assembly/cloud-assembly.spec.ts
@@ -72,6 +72,71 @@ describe('CloudAssemblyBuilder', () => {
     });
   });
 
+  describe('addAssetArtifact()', () => {
+    it('registers a cdkx:asset artifact in the manifest', () => {
+      const outdir = tmpDir();
+      const builder = new CloudAssemblyBuilder(outdir);
+      builder.addAssetArtifact({
+        id: 'asset.abc123ef',
+        hash: 'abc123ef',
+        path: 'assets/asset.abc123ef/cloud-init.yaml',
+        packaging: 'file',
+      });
+      builder.buildAssembly();
+
+      const manifest = JSON.parse(
+        fs.readFileSync(path.join(outdir, 'manifest.json'), 'utf-8'),
+      );
+      expect(manifest.artifacts['asset.abc123ef']).toEqual({
+        type: 'cdkx:asset',
+        properties: {
+          hash: 'abc123ef',
+          path: 'assets/asset.abc123ef/cloud-init.yaml',
+          packaging: 'file',
+        },
+      });
+      fs.rmSync(outdir, { recursive: true });
+    });
+
+    it('throws on duplicate asset artifact ID', () => {
+      const builder = new CloudAssemblyBuilder(tmpDir());
+      builder.addAssetArtifact({
+        id: 'asset.dup',
+        hash: 'dup',
+        path: 'assets/asset.dup/f',
+        packaging: 'file',
+      });
+      expect(() =>
+        builder.addAssetArtifact({
+          id: 'asset.dup',
+          hash: 'dup',
+          path: 'assets/asset.dup/f',
+          packaging: 'file',
+        }),
+      ).toThrow("Duplicate artifact ID 'asset.dup'");
+    });
+
+    it('CloudAssembly.stacks excludes asset artifacts', () => {
+      const outdir = tmpDir();
+      const builder = new CloudAssemblyBuilder(outdir);
+      builder.addArtifact({ id: 'my-stack', templateFile: 'my-stack.json' });
+      builder.addAssetArtifact({
+        id: 'asset.x',
+        hash: 'x',
+        path: 'assets/asset.x/f',
+        packaging: 'file',
+      });
+      const assembly = builder.buildAssembly();
+
+      expect(assembly.stacks).toHaveLength(1);
+      expect(assembly.stacks[0].properties).toHaveProperty(
+        'templateFile',
+        'my-stack.json',
+      );
+      fs.rmSync(outdir, { recursive: true });
+    });
+  });
+
   describe('buildAssembly()', () => {
     it('writes manifest.json to disk', () => {
       const outdir = tmpDir();

--- a/packages/core/src/lib/assembly/cloud-assembly.ts
+++ b/packages/core/src/lib/assembly/cloud-assembly.ts
@@ -8,8 +8,12 @@ export const MANIFEST_VERSION = '1.0.0';
  * Artifact type discriminator.
  * - `'cdkx:stack'` — a cloud-deploy stack (JSON template, processed by the engine).
  * - `'cdkx:local-files'` — a file-rendering stack (YAML files written to the repo, not deployed).
+ * - `'cdkx:asset'` — a staged asset (file or directory) referenced by stack resources.
  */
-export type ArtifactType = 'cdkx:stack' | 'cdkx:local-files';
+export type ArtifactType = 'cdkx:stack' | 'cdkx:local-files' | 'cdkx:asset';
+
+/** How an asset is packaged on disk. */
+export type AssetPackaging = 'file' | 'directory';
 
 /**
  * Describes a single stack artifact in the synthesis output.
@@ -57,6 +61,42 @@ export interface StackArtifact {
 }
 
 /**
+ * A staged asset artifact entry in `manifest.json`.
+ *
+ * Shape (per artifact entry in `artifacts`):
+ * ```json
+ * {
+ *   "type": "cdkx:asset",
+ *   "properties": {
+ *     "hash": "abc123ef…",
+ *     "path": "assets/asset.abc123ef/cloud-init.yaml",
+ *     "packaging": "file"
+ *   }
+ * }
+ * ```
+ */
+export interface AssetArtifact {
+  /** Artifact type discriminator — always `'cdkx:asset'`. */
+  readonly type: 'cdkx:asset';
+
+  /** Asset-level properties used by the runtime engine. */
+  readonly properties: {
+    /** SHA-256 hex digest of the asset's content. */
+    readonly hash: string;
+    /** Path to the staged asset, relative to the assembly outdir. */
+    readonly path: string;
+    /** How the asset is packaged (`'file'` or `'directory'`). */
+    readonly packaging: AssetPackaging;
+  };
+}
+
+/**
+ * Any artifact entry in the assembly manifest.
+ * Discriminate on `type` to narrow to `StackArtifact` or `AssetArtifact`.
+ */
+export type ManifestArtifact = StackArtifact | AssetArtifact;
+
+/**
  * The full content of the `manifest.json` file written to `cdkx.out/`.
  */
 export interface CloudAssemblyManifest {
@@ -67,7 +107,7 @@ export interface CloudAssemblyManifest {
    * All artifacts in this assembly, keyed by their artifact ID.
    * The artifact ID is the stack's `artifactId` (derived from the construct node path).
    */
-  readonly artifacts: Record<string, StackArtifact>;
+  readonly artifacts: Record<string, ManifestArtifact>;
 }
 
 /**
@@ -106,6 +146,23 @@ export interface AddArtifactOptions {
 }
 
 /**
+ * Input shape for `CloudAssemblyBuilder.addAssetArtifact()`.
+ */
+export interface AddAssetArtifactOptions {
+  /** Unique artifact ID within the assembly (e.g. `'asset.<hash>'`). */
+  readonly id: string;
+
+  /** SHA-256 hex digest of the asset's content. */
+  readonly hash: string;
+
+  /** Path to the staged asset, relative to the assembly outdir. */
+  readonly path: string;
+
+  /** How the asset is packaged on disk. */
+  readonly packaging: AssetPackaging;
+}
+
+/**
  * Mutable builder for a `CloudAssembly`.
  *
  * Created by `App` at the start of synthesis. Synthesizers use it to:
@@ -116,7 +173,7 @@ export interface AddArtifactOptions {
  * writes `manifest.json` and returns the immutable `CloudAssembly`.
  */
 export class CloudAssemblyBuilder {
-  private readonly artifacts: Record<string, StackArtifact> = {};
+  private readonly artifacts: Record<string, ManifestArtifact> = {};
 
   constructor(
     /** Absolute path to the output directory (e.g. `/project/cdkx.out`). */
@@ -161,6 +218,27 @@ export class CloudAssemblyBuilder {
   }
 
   /**
+   * Registers an asset artifact.
+   * Called by `Asset.synthesizeAsset()` after staging the file on disk.
+   */
+  public addAssetArtifact(options: AddAssetArtifactOptions): void {
+    if (this.artifacts[options.id] !== undefined) {
+      throw new Error(
+        `Duplicate artifact ID '${options.id}'. Each artifact must have a unique ID.`,
+      );
+    }
+    const artifact: AssetArtifact = {
+      type: 'cdkx:asset',
+      properties: {
+        hash: options.hash,
+        path: options.path,
+        packaging: options.packaging,
+      },
+    };
+    this.artifacts[options.id] = artifact;
+  }
+
+  /**
    * Seals the assembly: writes `manifest.json` and returns the immutable `CloudAssembly`.
    * Should be called exactly once, at the end of `App.synth()`.
    */
@@ -192,16 +270,22 @@ export class CloudAssembly {
   ) {}
 
   /**
-   * Returns the artifact for a given stack ID, or `undefined` if not found.
+   * Returns the stack artifact for a given ID, or `undefined` if not found
+   * or if the ID refers to a non-stack artifact.
    */
   public getStack(id: string): StackArtifact | undefined {
-    return this.manifest.artifacts[id];
+    const artifact = this.manifest.artifacts[id];
+    return artifact !== undefined && artifact.type !== 'cdkx:asset'
+      ? (artifact as StackArtifact)
+      : undefined;
   }
 
   /**
-   * Returns all stack artifacts in this assembly as an array (convenience getter).
+   * Returns all stack artifacts in this assembly (asset artifacts are excluded).
    */
   public get stacks(): StackArtifact[] {
-    return Object.values(this.manifest.artifacts);
+    return Object.values(this.manifest.artifacts).filter(
+      (a): a is StackArtifact => a.type !== 'cdkx:asset',
+    );
   }
 }

--- a/packages/core/src/lib/asset/asset-hasher.spec.ts
+++ b/packages/core/src/lib/asset/asset-hasher.spec.ts
@@ -1,0 +1,140 @@
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { AssetHasher } from './asset-hasher';
+
+function tmpFile(contents: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cdkx-asset-hasher-'));
+  const filePath = path.join(dir, 'file.txt');
+  fs.writeFileSync(filePath, contents, 'utf-8');
+  return filePath;
+}
+
+function tmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'cdkx-asset-hasher-dir-'));
+}
+
+describe('AssetHasher', () => {
+  describe('hashFile()', () => {
+    it('returns a SHA-256 hex digest (64 chars) of the file contents', () => {
+      const filePath = tmpFile('hello world');
+
+      const hash = AssetHasher.hashFile(filePath);
+
+      expect(hash).toMatch(/^[a-f0-9]{64}$/);
+      // Known SHA-256 of 'hello world'
+      expect(hash).toBe(
+        'b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9',
+      );
+    });
+
+    it('produces the same hash for identical content', () => {
+      const a = tmpFile('same content');
+      const b = tmpFile('same content');
+
+      expect(AssetHasher.hashFile(a)).toBe(AssetHasher.hashFile(b));
+    });
+
+    it('produces different hashes for different content', () => {
+      const a = tmpFile('one');
+      const b = tmpFile('two');
+
+      expect(AssetHasher.hashFile(a)).not.toBe(AssetHasher.hashFile(b));
+    });
+
+    it('throws when the file does not exist', () => {
+      expect(() =>
+        AssetHasher.hashFile('/nonexistent/path/to/file.txt'),
+      ).toThrow();
+    });
+  });
+
+  describe('hashDirectory()', () => {
+    it('returns a deterministic SHA-256 hex digest for a single-file directory', () => {
+      const dir = tmpDir();
+      fs.writeFileSync(path.join(dir, 'a.txt'), 'hello', 'utf-8');
+
+      const hash = AssetHasher.hashDirectory(dir);
+
+      // Deterministic: hash is derived from "<relPath>\0<sha256-of-contents>\n"
+      // for each entry, sorted by relPath.
+      const fileHash = crypto
+        .createHash('sha256')
+        .update(Buffer.from('hello', 'utf-8'))
+        .digest('hex');
+      const expected = crypto
+        .createHash('sha256')
+        .update(`a.txt\0${fileHash}\n`, 'utf-8')
+        .digest('hex');
+
+      expect(hash).toMatch(/^[a-f0-9]{64}$/);
+      expect(hash).toBe(expected);
+    });
+
+    it('produces the same hash for two directories with identical content laid out in different folders', () => {
+      const a = tmpDir();
+      fs.mkdirSync(path.join(a, 'inner'));
+      fs.writeFileSync(path.join(a, 'inner', 'x.txt'), 'x', 'utf-8');
+      fs.writeFileSync(path.join(a, 'top.txt'), 'top', 'utf-8');
+
+      const b = tmpDir();
+      // Create files in a different order to exercise non-deterministic FS
+      // traversal — the hash must still match a's.
+      fs.writeFileSync(path.join(b, 'top.txt'), 'top', 'utf-8');
+      fs.mkdirSync(path.join(b, 'inner'));
+      fs.writeFileSync(path.join(b, 'inner', 'x.txt'), 'x', 'utf-8');
+
+      expect(AssetHasher.hashDirectory(a)).toBe(AssetHasher.hashDirectory(b));
+    });
+
+    it('produces different hashes when file contents differ', () => {
+      const a = tmpDir();
+      const b = tmpDir();
+      fs.writeFileSync(path.join(a, 'f.txt'), 'one', 'utf-8');
+      fs.writeFileSync(path.join(b, 'f.txt'), 'two', 'utf-8');
+
+      expect(AssetHasher.hashDirectory(a)).not.toBe(
+        AssetHasher.hashDirectory(b),
+      );
+    });
+
+    it('produces different hashes when file names differ', () => {
+      const a = tmpDir();
+      const b = tmpDir();
+      fs.writeFileSync(path.join(a, 'alpha.txt'), 'same', 'utf-8');
+      fs.writeFileSync(path.join(b, 'beta.txt'), 'same', 'utf-8');
+
+      expect(AssetHasher.hashDirectory(a)).not.toBe(
+        AssetHasher.hashDirectory(b),
+      );
+    });
+
+    it('returns a stable hash for an empty directory without error', () => {
+      const a = tmpDir();
+      const b = tmpDir();
+
+      const hashA = AssetHasher.hashDirectory(a);
+      const hashB = AssetHasher.hashDirectory(b);
+
+      expect(hashA).toMatch(/^[a-f0-9]{64}$/);
+      expect(hashA).toBe(hashB);
+    });
+
+    it('follows symlinks: the target content contributes to the hash', () => {
+      const target = tmpDir();
+      const realFile = path.join(target, 'real.txt');
+      fs.writeFileSync(realFile, 'payload', 'utf-8');
+
+      // Dir A: holds a symlink "link.txt" -> real.txt
+      const a = tmpDir();
+      fs.symlinkSync(realFile, path.join(a, 'link.txt'));
+
+      // Dir B: holds a regular file "link.txt" with identical content.
+      const b = tmpDir();
+      fs.writeFileSync(path.join(b, 'link.txt'), 'payload', 'utf-8');
+
+      expect(AssetHasher.hashDirectory(a)).toBe(AssetHasher.hashDirectory(b));
+    });
+  });
+});

--- a/packages/core/src/lib/asset/asset-hasher.ts
+++ b/packages/core/src/lib/asset/asset-hasher.ts
@@ -1,0 +1,69 @@
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+/**
+ * Computes content hashes for asset files.
+ *
+ * Hashes are SHA-256 hex digests of raw file bytes. Identical file contents
+ * produce identical hashes regardless of file name, timestamps, or path.
+ */
+export class AssetHasher {
+  /**
+   * Returns the SHA-256 hex digest of the file's contents.
+   *
+   * Throws if the file does not exist or cannot be read.
+   */
+  public static hashFile(filePath: string): string {
+    const buffer = fs.readFileSync(filePath);
+    return crypto.createHash('sha256').update(buffer).digest('hex');
+  }
+
+  /**
+   * Returns a deterministic SHA-256 hex digest of a directory tree.
+   *
+   * The hash is computed over each file's relative path (POSIX separators)
+   * and the SHA-256 of its contents, joined with a NUL byte and terminated
+   * with a newline, in relative-path sort order. File permissions are not
+   * included. Symlinks are followed and their target contents contribute
+   * to the hash. An empty directory produces a stable hash.
+   */
+  public static hashDirectory(dirPath: string): string {
+    const entries = AssetHasher.walkDirectory(dirPath);
+    entries.sort((a, b) =>
+      a.relPath < b.relPath ? -1 : a.relPath > b.relPath ? 1 : 0,
+    );
+
+    const hash = crypto.createHash('sha256');
+    for (const entry of entries) {
+      const fileHash = crypto
+        .createHash('sha256')
+        .update(fs.readFileSync(entry.absPath))
+        .digest('hex');
+      hash.update(`${entry.relPath}\0${fileHash}\n`, 'utf-8');
+    }
+    return hash.digest('hex');
+  }
+
+  private static walkDirectory(
+    root: string,
+  ): Array<{ relPath: string; absPath: string }> {
+    const results: Array<{ relPath: string; absPath: string }> = [];
+    const stack: string[] = [root];
+    while (stack.length > 0) {
+      const current = stack.pop() as string;
+      const entries = fs.readdirSync(current);
+      for (const name of entries) {
+        const absPath = path.join(current, name);
+        const stat = fs.statSync(absPath);
+        if (stat.isDirectory()) {
+          stack.push(absPath);
+        } else if (stat.isFile()) {
+          const rel = path.relative(root, absPath).split(path.sep).join('/');
+          results.push({ relPath: rel, absPath });
+        }
+      }
+    }
+    return results;
+  }
+}

--- a/packages/core/src/lib/asset/asset-stager.spec.ts
+++ b/packages/core/src/lib/asset/asset-stager.spec.ts
@@ -1,0 +1,110 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { AssetStager } from './asset-stager';
+
+function tmpRoot(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'cdkx-asset-stager-'));
+}
+
+describe('AssetStager', () => {
+  describe('stageFile()', () => {
+    it('copies the source file into destDir with the given filename', () => {
+      const root = tmpRoot();
+      const src = path.join(root, 'source.txt');
+      const destDir = path.join(root, 'assets/asset.abc123');
+      fs.writeFileSync(src, 'payload', 'utf-8');
+
+      AssetStager.stageFile(src, destDir, 'staged.txt');
+
+      const stagedPath = path.join(destDir, 'staged.txt');
+      expect(fs.existsSync(stagedPath)).toBe(true);
+      expect(fs.readFileSync(stagedPath, 'utf-8')).toBe('payload');
+    });
+
+    it('creates the destination directory if it does not exist', () => {
+      const root = tmpRoot();
+      const src = path.join(root, 'source.txt');
+      const destDir = path.join(root, 'deep/nested/assets/asset.xyz');
+      fs.writeFileSync(src, 'x', 'utf-8');
+
+      AssetStager.stageFile(src, destDir, 'file.txt');
+
+      expect(fs.existsSync(path.join(destDir, 'file.txt'))).toBe(true);
+    });
+
+    it('preserves byte content (binary-safe copy)', () => {
+      const root = tmpRoot();
+      const src = path.join(root, 'bin.dat');
+      const destDir = path.join(root, 'dest');
+      const bytes = Buffer.from([0x00, 0xff, 0x10, 0x7f, 0x80]);
+      fs.writeFileSync(src, bytes);
+
+      AssetStager.stageFile(src, destDir, 'bin.dat');
+
+      const copied = fs.readFileSync(path.join(destDir, 'bin.dat'));
+      expect(copied.equals(bytes)).toBe(true);
+    });
+
+    it('throws when the source file does not exist', () => {
+      const root = tmpRoot();
+      expect(() =>
+        AssetStager.stageFile(
+          path.join(root, 'missing.txt'),
+          path.join(root, 'dest'),
+          'x.txt',
+        ),
+      ).toThrow();
+    });
+  });
+
+  describe('stageDirectory()', () => {
+    it('mirrors a nested directory tree into destDir', () => {
+      const root = tmpRoot();
+      const src = path.join(root, 'src');
+      fs.mkdirSync(src);
+      fs.writeFileSync(path.join(src, 'top.txt'), 'top', 'utf-8');
+      fs.mkdirSync(path.join(src, 'nested'));
+      fs.writeFileSync(path.join(src, 'nested', 'inner.txt'), 'inner', 'utf-8');
+
+      const dest = path.join(root, 'assets/asset.abc');
+      AssetStager.stageDirectory(src, dest);
+
+      expect(fs.readFileSync(path.join(dest, 'top.txt'), 'utf-8')).toBe('top');
+      expect(
+        fs.readFileSync(path.join(dest, 'nested', 'inner.txt'), 'utf-8'),
+      ).toBe('inner');
+    });
+
+    it('stages an empty directory without error', () => {
+      const root = tmpRoot();
+      const src = path.join(root, 'empty');
+      fs.mkdirSync(src);
+      const dest = path.join(root, 'assets/asset.empty');
+
+      expect(() => AssetStager.stageDirectory(src, dest)).not.toThrow();
+
+      expect(fs.existsSync(dest)).toBe(true);
+      expect(fs.readdirSync(dest)).toEqual([]);
+    });
+
+    it('follows symlinks and copies the target contents', () => {
+      const root = tmpRoot();
+      const externalTarget = path.join(root, 'external.txt');
+      fs.writeFileSync(externalTarget, 'linked-payload', 'utf-8');
+
+      const src = path.join(root, 'src');
+      fs.mkdirSync(src);
+      fs.symlinkSync(externalTarget, path.join(src, 'alias.txt'));
+
+      const dest = path.join(root, 'assets/asset.lnk');
+      AssetStager.stageDirectory(src, dest);
+
+      const copied = path.join(dest, 'alias.txt');
+      expect(fs.existsSync(copied)).toBe(true);
+      // lstat must report a regular file (not a symlink) — target content copied.
+      expect(fs.lstatSync(copied).isSymbolicLink()).toBe(false);
+      expect(fs.readFileSync(copied, 'utf-8')).toBe('linked-payload');
+    });
+  });
+});

--- a/packages/core/src/lib/asset/asset-stager.ts
+++ b/packages/core/src/lib/asset/asset-stager.ts
@@ -1,0 +1,47 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+/**
+ * Copies asset files into the cloud assembly staging area.
+ *
+ * `stageFile` copies a single source file into `destDir` under the given
+ * `fileName`, creating the destination directory if necessary. Copies preserve
+ * raw byte content.
+ */
+export class AssetStager {
+  /**
+   * Copies `src` to `destDir/fileName`. Creates `destDir` recursively if
+   * missing. Throws if `src` does not exist.
+   */
+  public static stageFile(
+    src: string,
+    destDir: string,
+    fileName: string,
+  ): void {
+    if (!fs.existsSync(destDir)) {
+      fs.mkdirSync(destDir, { recursive: true });
+    }
+    fs.copyFileSync(src, path.join(destDir, fileName));
+  }
+
+  /**
+   * Recursively copies the contents of `src` into `destDir`. Creates `destDir`
+   * (including parents) when it does not exist. Symlinks encountered during
+   * traversal are followed and their target contents are copied.
+   */
+  public static stageDirectory(src: string, destDir: string): void {
+    if (!fs.existsSync(destDir)) {
+      fs.mkdirSync(destDir, { recursive: true });
+    }
+    for (const name of fs.readdirSync(src)) {
+      const srcEntry = path.join(src, name);
+      const destEntry = path.join(destDir, name);
+      const stat = fs.statSync(srcEntry);
+      if (stat.isDirectory()) {
+        AssetStager.stageDirectory(srcEntry, destEntry);
+      } else if (stat.isFile()) {
+        fs.copyFileSync(srcEntry, destEntry);
+      }
+    }
+  }
+}

--- a/packages/core/src/lib/asset/asset.spec.ts
+++ b/packages/core/src/lib/asset/asset.spec.ts
@@ -1,0 +1,201 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { App } from '../app/app';
+import { Stack } from '../stack/stack';
+import { Asset } from './asset';
+import { AssetHasher } from './asset-hasher';
+import { CloudAssemblyBuilder } from '../assembly/cloud-assembly';
+
+function tmpFile(name: string, contents: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cdkx-asset-'));
+  const filePath = path.join(dir, name);
+  fs.writeFileSync(filePath, contents, 'utf-8');
+  return filePath;
+}
+
+function tmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'cdkx-asset-dir-'));
+}
+
+describe('Asset', () => {
+  it('computes assetHash as SHA-256 of the source file contents', () => {
+    const filePath = tmpFile('cloud-init.yaml', 'hello: world');
+    const app = new App();
+    const stack = new Stack(app, 'S');
+
+    const asset = new Asset(stack, 'Asset', { path: filePath });
+
+    expect(asset.assetHash).toBe(AssetHasher.hashFile(filePath));
+  });
+
+  describe('absolutePath', () => {
+    it('resolves to <outdir>/assets/asset.<hash>/<fileName>', () => {
+      const outdir = fs.mkdtempSync(path.join(os.tmpdir(), 'cdkx-asset-abs-'));
+      const filePath = tmpFile('cloud-init.yaml', 'x: 1');
+      const app = new App({ outdir });
+      const stack = new Stack(app, 'S');
+
+      const asset = new Asset(stack, 'Asset', { path: filePath });
+
+      expect(asset.absolutePath).toBe(
+        path.join(
+          outdir,
+          'assets',
+          `asset.${asset.assetHash}`,
+          'cloud-init.yaml',
+        ),
+      );
+    });
+
+    it('is absolute even when App.outdir is relative', () => {
+      const filePath = tmpFile('cloud-init.yaml', 'y: 2');
+      const app = new App({ outdir: 'cdkx.out' });
+      const stack = new Stack(app, 'S');
+
+      const asset = new Asset(stack, 'Asset', { path: filePath });
+
+      expect(path.isAbsolute(asset.absolutePath)).toBe(true);
+    });
+  });
+
+  describe('isAsset()', () => {
+    it('returns true for Asset instances', () => {
+      const filePath = tmpFile('f.txt', 'x');
+      const app = new App();
+      const stack = new Stack(app, 'S');
+      const asset = new Asset(stack, 'Asset', { path: filePath });
+
+      expect(Asset.isAsset(asset)).toBe(true);
+    });
+
+    it('returns false for non-Asset values', () => {
+      expect(Asset.isAsset({})).toBe(false);
+      expect(Asset.isAsset(undefined)).toBe(false);
+      expect(Asset.isAsset('string')).toBe(false);
+    });
+  });
+
+  it('throws when the source file does not exist', () => {
+    const app = new App();
+    const stack = new Stack(app, 'S');
+    expect(
+      () =>
+        new Asset(stack, 'Asset', { path: '/nonexistent/path/to/file.yaml' }),
+    ).toThrow();
+  });
+
+  it('throws when neither path nor directoryPath is provided', () => {
+    const app = new App();
+    const stack = new Stack(app, 'S');
+    expect(() => new Asset(stack, 'Asset', {})).toThrow(/path.*directoryPath/i);
+  });
+
+  it('throws when both path and directoryPath are provided', () => {
+    const filePath = tmpFile('x.txt', 'x');
+    const dirPath = tmpDir();
+    const app = new App();
+    const stack = new Stack(app, 'S');
+    expect(
+      () =>
+        new Asset(stack, 'Asset', { path: filePath, directoryPath: dirPath }),
+    ).toThrow(/path.*directoryPath/i);
+  });
+
+  describe('directory source', () => {
+    it('computes assetHash via AssetHasher.hashDirectory() and sets absolutePath to the staged directory (no file name appended)', () => {
+      const outdir = fs.mkdtempSync(
+        path.join(os.tmpdir(), 'cdkx-asset-dir-out-'),
+      );
+      const dirPath = tmpDir();
+      fs.writeFileSync(path.join(dirPath, 'a.txt'), 'hello', 'utf-8');
+
+      const app = new App({ outdir });
+      const stack = new Stack(app, 'S');
+      const asset = new Asset(stack, 'Ansible', { directoryPath: dirPath });
+
+      expect(asset.packaging).toBe('directory');
+      expect(asset.assetHash).toBe(AssetHasher.hashDirectory(dirPath));
+      expect(asset.absolutePath).toBe(
+        path.join(outdir, 'assets', `asset.${asset.assetHash}`),
+      );
+    });
+
+    it('synthesizeAsset() mirrors the directory tree and registers a cdkx:asset artifact with packaging:"directory"', () => {
+      const dirPath = tmpDir();
+      fs.writeFileSync(path.join(dirPath, 'top.txt'), 'top', 'utf-8');
+      fs.mkdirSync(path.join(dirPath, 'nested'));
+      fs.writeFileSync(path.join(dirPath, 'nested', 'inner.txt'), 'x', 'utf-8');
+
+      const outdir = fs.mkdtempSync(
+        path.join(os.tmpdir(), 'cdkx-asset-dir-synth-'),
+      );
+      const builder = new CloudAssemblyBuilder(outdir);
+      const app = new App({ outdir });
+      const stack = new Stack(app, 'S');
+      const asset = new Asset(stack, 'Role', { directoryPath: dirPath });
+
+      asset.synthesizeAsset({ outdir, assembly: builder });
+
+      const stagedDir = path.join(outdir, 'assets', `asset.${asset.assetHash}`);
+      expect(fs.readFileSync(path.join(stagedDir, 'top.txt'), 'utf-8')).toBe(
+        'top',
+      );
+      expect(
+        fs.readFileSync(path.join(stagedDir, 'nested', 'inner.txt'), 'utf-8'),
+      ).toBe('x');
+
+      builder.buildAssembly();
+      const manifest = JSON.parse(
+        fs.readFileSync(path.join(outdir, 'manifest.json'), 'utf-8'),
+      );
+      const artifactId = `asset.${asset.assetHash}`;
+      expect(manifest.artifacts[artifactId]).toEqual({
+        type: 'cdkx:asset',
+        properties: {
+          hash: asset.assetHash,
+          path: `assets/asset.${asset.assetHash}`,
+          packaging: 'directory',
+        },
+      });
+    });
+  });
+
+  describe('synthesizeAsset()', () => {
+    it('stages the file under assets/asset.<hash>/<fileName> and registers a cdkx:asset artifact', () => {
+      const filePath = tmpFile('cloud-init.yaml', 'users: []');
+      const outdir = fs.mkdtempSync(
+        path.join(os.tmpdir(), 'cdkx-asset-synth-'),
+      );
+      const builder = new CloudAssemblyBuilder(outdir);
+      const app = new App({ outdir });
+      const stack = new Stack(app, 'S');
+      const asset = new Asset(stack, 'Asset', { path: filePath });
+
+      asset.synthesizeAsset({ outdir, assembly: builder });
+
+      const stagedPath = path.join(
+        outdir,
+        'assets',
+        `asset.${asset.assetHash}`,
+        'cloud-init.yaml',
+      );
+      expect(fs.existsSync(stagedPath)).toBe(true);
+      expect(fs.readFileSync(stagedPath, 'utf-8')).toBe('users: []');
+
+      builder.buildAssembly();
+      const manifest = JSON.parse(
+        fs.readFileSync(path.join(outdir, 'manifest.json'), 'utf-8'),
+      );
+      const artifactId = `asset.${asset.assetHash}`;
+      expect(manifest.artifacts[artifactId]).toEqual({
+        type: 'cdkx:asset',
+        properties: {
+          hash: asset.assetHash,
+          path: `assets/asset.${asset.assetHash}/cloud-init.yaml`,
+          packaging: 'file',
+        },
+      });
+    });
+  });
+});

--- a/packages/core/src/lib/asset/asset.ts
+++ b/packages/core/src/lib/asset/asset.ts
@@ -1,0 +1,151 @@
+import * as path from 'node:path';
+import { Construct } from 'constructs';
+import { App } from '../app/app';
+import { AssetPackaging } from '../assembly/cloud-assembly';
+import { ISynthesisSession } from '../synthesizer/synthesizer';
+import { AssetHasher } from './asset-hasher';
+import { AssetStager } from './asset-stager';
+
+/**
+ * Properties for `Asset`. Exactly one of `path` or `directoryPath` must be
+ * provided.
+ */
+export interface AssetProps {
+  /**
+   * Path to a local file to include in the cloud assembly. Relative paths are
+   * resolved against the current working directory at construction time.
+   */
+  readonly path?: string;
+
+  /**
+   * Path to a local directory to include in the cloud assembly. Relative paths
+   * are resolved against the current working directory at construction time.
+   */
+  readonly directoryPath?: string;
+}
+
+/**
+ * An asset is any file or directory bundled into the cloud assembly during
+ * synthesis.
+ *
+ * At synth time, the source is staged into `cdkx.out/assets/asset.<hash>/` and
+ * registered as a `cdkx:asset` artifact in `manifest.json`. L1 constructs
+ * consume the staged asset by reading `asset.absolutePath`, which is a plain
+ * string known at construction time.
+ */
+export interface IAsset {
+  /** SHA-256 hex digest of the asset's content. */
+  readonly assetHash: string;
+
+  /**
+   * Absolute filesystem path to the staged asset inside the cloud assembly.
+   * For file assets: `<outdir>/assets/asset.<hash>/<fileName>`.
+   * For directory assets: `<outdir>/assets/asset.<hash>`.
+   */
+  readonly absolutePath: string;
+}
+
+/**
+ * A local-file asset. Hashes the file contents at construction time and
+ * exposes the staged file path as a plain string for use in resource
+ * properties.
+ *
+ * @example
+ * const asset = new Asset(stack, 'CloudInit', { path: './cloud-init.yaml' });
+ * new Server(stack, 'Server', { userData: asset.absolutePath });
+ */
+export class Asset extends Construct implements IAsset {
+  /** Type guard: returns true when `x` is an `Asset` instance. */
+  public static isAsset(x: unknown): x is Asset {
+    return x instanceof Asset;
+  }
+
+  /** SHA-256 hex digest of the file's contents. */
+  public readonly assetHash: string;
+
+  /** Absolute path to the source file. */
+  public readonly sourcePath: string;
+
+  /**
+   * File name that will be used inside the staged asset directory.
+   * Undefined for directory-packaged assets — the full tree is staged under
+   * `asset.<hash>/` with no wrapping file name.
+   */
+  public readonly fileName: string | undefined;
+
+  /** Absolute path to the staged asset inside the cloud assembly. */
+  public readonly absolutePath: string;
+
+  /** How the asset is packaged on disk. */
+  public readonly packaging: AssetPackaging;
+
+  constructor(scope: Construct, id: string, props: AssetProps) {
+    super(scope, id);
+
+    const hasPath = props.path !== undefined;
+    const hasDirectoryPath = props.directoryPath !== undefined;
+
+    if (hasPath && hasDirectoryPath) {
+      throw new Error(
+        `Asset '${id}': specify either 'path' or 'directoryPath', not both.`,
+      );
+    }
+    if (!hasPath && !hasDirectoryPath) {
+      throw new Error(
+        `Asset '${id}': one of 'path' or 'directoryPath' must be provided.`,
+      );
+    }
+
+    if (hasDirectoryPath) {
+      this.sourcePath = path.resolve(props.directoryPath as string);
+      this.packaging = 'directory';
+      this.fileName = undefined;
+      this.assetHash = AssetHasher.hashDirectory(this.sourcePath);
+    } else {
+      this.sourcePath = path.resolve(props.path as string);
+      this.packaging = 'file';
+      this.fileName = path.basename(this.sourcePath);
+      this.assetHash = AssetHasher.hashFile(this.sourcePath);
+    }
+
+    const outdir = path.resolve(App.of(this).outdir);
+    const assetDir = path.join(outdir, 'assets', `asset.${this.assetHash}`);
+    this.absolutePath =
+      this.packaging === 'directory'
+        ? assetDir
+        : path.join(assetDir, this.fileName as string);
+  }
+
+  /**
+   * Stages the asset file into the cloud assembly and registers its artifact.
+   *
+   * Copies the source file to `<outdir>/assets/asset.<hash>/<fileName>` and
+   * registers a `cdkx:asset` entry in `manifest.json`. Called by `App.synth()`
+   * during Phase 0 (before stack synthesis).
+   */
+  public synthesizeAsset(session: ISynthesisSession): void {
+    const artifactId = `asset.${this.assetHash}`;
+    const relativeDir = path.posix.join('assets', artifactId);
+    const absoluteDir = path.join(session.outdir, 'assets', artifactId);
+
+    if (this.packaging === 'directory') {
+      AssetStager.stageDirectory(this.sourcePath, absoluteDir);
+      session.assembly.addAssetArtifact({
+        id: artifactId,
+        hash: this.assetHash,
+        path: relativeDir,
+        packaging: 'directory',
+      });
+      return;
+    }
+
+    const fileName = this.fileName as string;
+    AssetStager.stageFile(this.sourcePath, absoluteDir, fileName);
+    session.assembly.addAssetArtifact({
+      id: artifactId,
+      hash: this.assetHash,
+      path: path.posix.join(relativeDir, fileName),
+      packaging: 'file',
+    });
+  }
+}

--- a/packages/core/src/lib/asset/index.ts
+++ b/packages/core/src/lib/asset/index.ts
@@ -1,0 +1,3 @@
+export * from './asset';
+export * from './asset-hasher';
+export * from './asset-stager';

--- a/packages/engine/src/lib/assembly/assembly-types.ts
+++ b/packages/engine/src/lib/assembly/assembly-types.ts
@@ -1,4 +1,22 @@
 /**
+ * A staged asset read from the cloud assembly manifest.
+ *
+ * Produced by `CloudAssemblyReader.readAssets()`. The `absolutePath` is
+ * resolved against the assembly outdir so engine code can pass it straight
+ * to provider handlers.
+ */
+export interface AssemblyAsset {
+  /** Artifact ID (e.g. `'asset.<hash>'`). */
+  readonly id: string;
+  /** SHA-256 hex digest of the asset's content. */
+  readonly hash: string;
+  /** Absolute path to the staged file or directory on disk. */
+  readonly absolutePath: string;
+  /** How the asset is packaged on disk. */
+  readonly packaging: 'file' | 'directory';
+}
+
+/**
  * A resolved output value declared by a stack.
  * Corresponds to a `StackOutput` construct in the synthesized JSON.
  */

--- a/packages/engine/src/lib/assembly/cloud-assembly-reader.spec.ts
+++ b/packages/engine/src/lib/assembly/cloud-assembly-reader.spec.ts
@@ -1,5 +1,5 @@
 import { CloudAssemblyReader } from './cloud-assembly-reader';
-import type { AssemblyStack } from './assembly-types';
+import type { AssemblyAsset, AssemblyStack } from './assembly-types';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -439,6 +439,98 @@ describe('CloudAssemblyReader', () => {
           outputKey: 'NetworkId',
         });
       });
+    });
+  });
+
+  describe('readAssets()', () => {
+    it('returns an empty array when the manifest has no cdkx:asset artifacts', () => {
+      const manifest = {
+        version: MANIFEST_VERSION,
+        artifacts: {
+          MyStack: {
+            type: 'cdkx:stack',
+            properties: { templateFile: 'MyStack.json' },
+          },
+        },
+      };
+      const files: Record<string, string> = {
+        [`${OUTDIR}/manifest.json`]: JSON.stringify(manifest),
+        [`${OUTDIR}/MyStack.json`]: makeTemplate(),
+      };
+
+      const assets = new CloudAssemblyReader(
+        OUTDIR,
+        makeDeps(files),
+      ).readAssets();
+
+      expect(assets).toEqual([]);
+    });
+
+    it('returns AssemblyAsset entries for cdkx:asset artifacts with absolute paths', () => {
+      const manifest = {
+        version: MANIFEST_VERSION,
+        artifacts: {
+          'asset.abc123ef': {
+            type: 'cdkx:asset',
+            properties: {
+              hash: 'abc123ef',
+              path: 'assets/asset.abc123ef/cloud-init.yaml',
+              packaging: 'file',
+            },
+          },
+          MyStack: {
+            type: 'cdkx:stack',
+            properties: { templateFile: 'MyStack.json' },
+          },
+        },
+      };
+      const files: Record<string, string> = {
+        [`${OUTDIR}/manifest.json`]: JSON.stringify(manifest),
+        [`${OUTDIR}/MyStack.json`]: makeTemplate(),
+      };
+
+      const assets: AssemblyAsset[] = new CloudAssemblyReader(
+        OUTDIR,
+        makeDeps(files),
+      ).readAssets();
+
+      expect(assets).toHaveLength(1);
+      expect(assets[0]).toEqual({
+        id: 'asset.abc123ef',
+        hash: 'abc123ef',
+        absolutePath: `${OUTDIR}/assets/asset.abc123ef/cloud-init.yaml`,
+        packaging: 'file',
+      });
+    });
+  });
+
+  describe('read() with mixed asset + stack artifacts', () => {
+    it('ignores cdkx:asset artifacts — only returns stacks', () => {
+      const manifest = {
+        version: MANIFEST_VERSION,
+        artifacts: {
+          'asset.x': {
+            type: 'cdkx:asset',
+            properties: {
+              hash: 'x',
+              path: 'assets/asset.x/f.txt',
+              packaging: 'file',
+            },
+          },
+          MyStack: {
+            type: 'cdkx:stack',
+            properties: { templateFile: 'MyStack.json' },
+          },
+        },
+      };
+      const files: Record<string, string> = {
+        [`${OUTDIR}/manifest.json`]: JSON.stringify(manifest),
+        [`${OUTDIR}/MyStack.json`]: makeTemplate(),
+      };
+
+      const stacks = new CloudAssemblyReader(OUTDIR, makeDeps(files)).read();
+
+      expect(stacks.map((s) => s.id)).toEqual(['MyStack']);
     });
   });
 });

--- a/packages/engine/src/lib/assembly/cloud-assembly-reader.ts
+++ b/packages/engine/src/lib/assembly/cloud-assembly-reader.ts
@@ -1,6 +1,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import type {
+  AssemblyAsset,
   AssemblyOutput,
   AssemblyResource,
   AssemblyStack,
@@ -19,10 +20,22 @@ export interface CloudAssemblyReaderDeps {
 
 interface ManifestArtifact {
   type: string;
-  properties: { templateFile: string };
+  properties:
+    | { templateFile: string }
+    | { hash: string; path: string; packaging: 'file' | 'directory' };
   displayName?: string;
   outputKeys?: string[];
   dependencies?: string[];
+}
+
+interface ManifestAssetArtifactProps {
+  hash: string;
+  path: string;
+  packaging: 'file' | 'directory';
+}
+
+interface ManifestStackArtifactProps {
+  templateFile: string;
 }
 
 interface ManifestJson {
@@ -96,6 +109,30 @@ export class CloudAssemblyReader {
     return stacks;
   }
 
+  /**
+   * Read all `cdkx:asset` artifacts from `manifest.json`.
+   *
+   * Returns an empty array when the manifest has no asset artifacts.
+   * Each asset's `absolutePath` is resolved against the assembly outdir.
+   *
+   * @throws if `manifest.json` is not found or is malformed.
+   */
+  public readAssets(): AssemblyAsset[] {
+    const manifest = this.readManifest();
+    const assets: AssemblyAsset[] = [];
+    for (const [id, artifact] of Object.entries(manifest.artifacts)) {
+      if (artifact.type !== 'cdkx:asset') continue;
+      const props = artifact.properties as ManifestAssetArtifactProps;
+      assets.push({
+        id,
+        hash: props.hash,
+        absolutePath: path.join(this.outdir, props.path),
+        packaging: props.packaging,
+      });
+    }
+    return assets;
+  }
+
   // ─── Private helpers ───────────────────────────────────────────────────────
 
   private readManifest(): ManifestJson {
@@ -119,18 +156,18 @@ export class CloudAssemblyReader {
   }
 
   private readStacks(manifest: ManifestJson): AssemblyStack[] {
-    const stackIds = Object.keys(manifest.artifacts);
+    const stackIds = Object.keys(manifest.artifacts).filter(
+      (id) => manifest.artifacts[id].type !== 'cdkx:asset',
+    );
 
     return stackIds.map((stackId) => {
       const artifact = manifest.artifacts[stackId];
-      const templatePath = path.join(
-        this.outdir,
-        artifact.properties.templateFile,
-      );
+      const stackProps = artifact.properties as ManifestStackArtifactProps;
+      const templatePath = path.join(this.outdir, stackProps.templateFile);
 
       if (!this.fileExists(templatePath)) {
         throw new Error(
-          `Stack template '${artifact.properties.templateFile}' not found at '${templatePath}'.`,
+          `Stack template '${stackProps.templateFile}' not found at '${templatePath}'.`,
         );
       }
 
@@ -140,7 +177,7 @@ export class CloudAssemblyReader {
         template = JSON.parse(raw) as StackTemplate;
       } catch {
         throw new Error(
-          `Failed to parse stack template '${artifact.properties.templateFile}': invalid JSON.`,
+          `Failed to parse stack template '${stackProps.templateFile}': invalid JSON.`,
         );
       }
 
@@ -153,7 +190,7 @@ export class CloudAssemblyReader {
 
       const stack: AssemblyStack = {
         id: stackId,
-        templateFile: artifact.properties.templateFile,
+        templateFile: stackProps.templateFile,
         ...(artifact.displayName !== undefined
           ? { displayName: artifact.displayName }
           : {}),

--- a/packages/engine/src/lib/engine/deployment-engine.spec.ts
+++ b/packages/engine/src/lib/engine/deployment-engine.spec.ts
@@ -1,3 +1,6 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import { DeploymentEngine } from './deployment-engine';
 import { DeploymentPlanner } from '../planner/deployment-planner';
 import { StackStatus } from '../states/stack-status';
@@ -619,6 +622,83 @@ describe('DeploymentEngine', () => {
       const stacks = [makeStack('S', [])];
       const plan = makePlan(['S'], { S: [] });
       const result = await engine.deploy(stacks, plan);
+      expect(result.success).toBe(true);
+    });
+  });
+
+  // ─── verifyAssets() pre-deploy check ─────────────────────────────────────────
+
+  describe('verifyAssets() pre-deploy check', () => {
+    function makeAssemblyDir(
+      assetEntries: Record<string, { hash: string; relPath: string }>,
+      stagedFiles: Record<string, string> = {},
+    ): string {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cdkx-verify-'));
+      const artifacts: Record<string, unknown> = {};
+      for (const [id, entry] of Object.entries(assetEntries)) {
+        artifacts[id] = {
+          type: 'cdkx:asset',
+          properties: {
+            hash: entry.hash,
+            path: entry.relPath,
+            packaging: 'file',
+          },
+        };
+      }
+      fs.writeFileSync(
+        path.join(dir, 'manifest.json'),
+        JSON.stringify({ version: '1.0.0', artifacts }),
+      );
+      for (const [relPath, contents] of Object.entries(stagedFiles)) {
+        const abs = path.join(dir, relPath);
+        fs.mkdirSync(path.dirname(abs), { recursive: true });
+        fs.writeFileSync(abs, contents);
+      }
+      return dir;
+    }
+
+    function makeEngineForAssemblyDir(assemblyDir: string): DeploymentEngine {
+      const bus = new EventBus<EngineEvent>();
+      const persistence = makeNullPersistence();
+      const stateManager = new EngineStateManager(bus, persistence);
+      return new DeploymentEngine({
+        adapters: { test: successAdapter('phys-1') as ProviderAdapter },
+        assemblyDir,
+        stateDir: '/fake/state',
+        stateManager,
+        persistence,
+        eventBus: bus,
+        deployLock: makeMockDeployLock(),
+      });
+    }
+
+    it('throws a clear error before any adapter call when a staged asset file is missing', async () => {
+      const assemblyDir = makeAssemblyDir({
+        'asset.deadbeef': {
+          hash: 'deadbeef',
+          relPath: 'assets/asset.deadbeef/cloud-init.yaml',
+        },
+      });
+      const engine = makeEngineForAssemblyDir(assemblyDir);
+
+      await expect(engine.deploy([], makePlan([], {}))).rejects.toThrow(
+        /asset.*missing|cloud-init\.yaml/i,
+      );
+    });
+
+    it('proceeds with deploy when every staged asset file exists on disk', async () => {
+      const assemblyDir = makeAssemblyDir(
+        {
+          'asset.cafebabe': {
+            hash: 'cafebabe',
+            relPath: 'assets/asset.cafebabe/cloud-init.yaml',
+          },
+        },
+        { 'assets/asset.cafebabe/cloud-init.yaml': '#cloud-config\n' },
+      );
+      const engine = makeEngineForAssemblyDir(assemblyDir);
+
+      const result = await engine.deploy([], makePlan([], {}));
       expect(result.success).toBe(true);
     });
   });

--- a/packages/engine/src/lib/engine/deployment-engine.ts
+++ b/packages/engine/src/lib/engine/deployment-engine.ts
@@ -1,3 +1,4 @@
+import * as fs from 'node:fs';
 import { StackStatus } from '../states/stack-status';
 import { ResourceStatus } from '../states/resource-status';
 import { EventBus } from '../events/event-bus';
@@ -304,6 +305,39 @@ export class DeploymentEngine {
   }
 
   /**
+   * Verifies that every `cdkx:asset` artifact declared in the manifest is
+   * staged on disk under `assemblyDir`. Throws a clear error listing the
+   * missing files when one or more are absent — fail fast before any
+   * adapter call mutates provider state.
+   */
+  private verifyAssets(): void {
+    let assets;
+    try {
+      const reader = new CloudAssemblyReader(this.options.assemblyDir);
+      assets = reader.readAssets();
+    } catch {
+      // No manifest / unreadable manifest: nothing to verify. The downstream
+      // `readAssembly()` call will surface the underlying error if relevant.
+      return;
+    }
+
+    const missing: string[] = [];
+    for (const asset of assets) {
+      if (!fs.existsSync(asset.absolutePath)) {
+        missing.push(asset.absolutePath);
+      }
+    }
+
+    if (missing.length > 0) {
+      throw new Error(
+        `Cannot deploy: ${missing.length} asset file(s) missing from the cloud assembly. ` +
+          `Run 'cdkx synth' to regenerate the assembly. Missing:\n  - ` +
+          missing.join('\n  - '),
+      );
+    }
+  }
+
+  /**
    * Subscribe to engine events emitted during deployment.
    * Returns an unsubscribe function.
    */
@@ -422,6 +456,9 @@ export class DeploymentEngine {
       const assemblyStacks = stacks ?? this.readAssembly();
       return await this.resumeRollback(assemblyStacks);
     }
+
+    // Pre-deploy: fail fast if any staged asset file is missing from disk.
+    this.verifyAssets();
 
     // If no stacks provided, read assembly and create plan internally
     const actualStacks = stacks ?? this.readAssembly();
@@ -940,7 +977,7 @@ export class DeploymentEngine {
       };
     }
 
-    // Resolve { ref, attr } and { stackRef, outputKey } tokens in properties.
+    // Resolve { ref, attr } and { stackRef, outputKey } tokens.
     const resolver = new DeployTimeResolver(
       this.stateManager.getState(),
       stack.id,


### PR DESCRIPTION
Introduce the Asset module for managing local-file assets in the cloud assembly. Implement a pre-deploy check to verify that all declared assets are staged on disk, enhancing deployment reliability. Update documentation and tests to cover new features and ensure proper functionality.