### PR TITLE
feat(core): add IResolvable marker and Resolvable utility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,3 +21,9 @@
 - The `nx-generate` skill handles generator discovery internally - don't call nx_docs just to look up generator syntax
 
 <!-- nx configuration end-->
+
+## Development Guide
+
+- **Module layout**: each class/module in a library lives in its own folder under `src/lib/<module-name>/`, containing the implementation file and its co-located `*.spec.ts` side by side (e.g. `src/lib/resolvable/resolvable.ts` + `src/lib/resolvable/resolvable.spec.ts`). This is more maintainable than flat files directly under `src/`.
+- **OOP-first**: the codebase follows strict OOP — no loose exported functions from a module; any utility is a static method on a class (e.g. `Stack.of()`, `App.of()`, `Resource.of()`, `Resolvable.isResolvable()`). Non-instantiable utility classes use a private constructor.
+- **JSDoc for jsii**: this package will later be compiled through jsii to generate multi-language bindings (Python, Java, .NET, Go), which derive their docs directly from these comments — there is no separate documentation source. Every exported class, interface, and public/static method needs a full doc comment: a summary of intent, `@param` for each parameter, `@returns` describing the value (call out type-predicate narrowing where relevant), and an `@example` whenever a usage snippet clarifies the call site. Fields/methods with no parameters (e.g. `IResolvable.resolve()`) don't need `@param`/`@example` — a summary is enough until a concrete implementation exists to illustrate.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -37,6 +37,13 @@ export default [
       '**/*.mjs',
     ],
     // Override or add rules here
-    rules: {},
+    rules: {
+      // Static-only utility classes (Stack.of(), Resource.of(), Resolvable, ...)
+      // use an intentionally empty private constructor to prevent instantiation.
+      '@typescript-eslint/no-empty-function': [
+        'error',
+        { allow: ['private-constructors', 'protected-constructors'] },
+      ],
+    },
   },
 ];

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,1 +1,2 @@
 export * from './lib/core.js';
+export * from './lib/resolvable/resolvable.js';

--- a/packages/core/src/lib/resolvable/resolvable.spec.ts
+++ b/packages/core/src/lib/resolvable/resolvable.spec.ts
@@ -1,0 +1,67 @@
+import { Resolvable } from './resolvable.js';
+import type { IResolvable, PropertyValue } from './resolvable.js';
+
+describe('Resolvable', () => {
+  describe('isResolvable', () => {
+    it('returns true for an object with a resolve method', () => {
+      const value: IResolvable = { resolve: () => 'x' };
+      expect(Resolvable.isResolvable(value)).toBe(true);
+    });
+
+    it('returns false for null', () => {
+      expect(Resolvable.isResolvable(null)).toBe(false);
+    });
+
+    it('returns false for undefined', () => {
+      expect(Resolvable.isResolvable(undefined)).toBe(false);
+    });
+
+    it('returns false for a string', () => {
+      expect(Resolvable.isResolvable('a string')).toBe(false);
+    });
+
+    it('returns false for a number', () => {
+      expect(Resolvable.isResolvable(42)).toBe(false);
+    });
+
+    it('returns false for an array', () => {
+      expect(Resolvable.isResolvable([1, 2, 3])).toBe(false);
+    });
+
+    it('returns false for a plain object without resolve', () => {
+      expect(Resolvable.isResolvable({ foo: 'bar' })).toBe(false);
+    });
+
+    it('returns false for an object whose resolve property is not a function', () => {
+      expect(Resolvable.isResolvable({ resolve: 'foo' })).toBe(false);
+    });
+  });
+
+  describe('type-level checks', () => {
+    it('does not allow direct instantiation (private constructor)', () => {
+      // @ts-expect-error - Resolvable's constructor is private; it is a static-only utility class
+      const instance = new Resolvable();
+      expect(instance).toBeInstanceOf(Resolvable);
+    });
+
+    it('accepts an IResolvable nested anywhere within a PropertyValue', () => {
+      const resolvable: IResolvable = { resolve: () => 'resolved' };
+
+      const value: PropertyValue = {
+        name: 'example',
+        count: 1,
+        enabled: true,
+        tags: ['a', 'b', resolvable],
+        nested: {
+          direct: resolvable,
+          deeper: {
+            list: [resolvable, { inner: resolvable }],
+          },
+        },
+      };
+
+      expect(Resolvable.isResolvable(resolvable)).toBe(true);
+      expect(Resolvable.isResolvable(value)).toBe(false);
+    });
+  });
+});

--- a/packages/core/src/lib/resolvable/resolvable.ts
+++ b/packages/core/src/lib/resolvable/resolvable.ts
@@ -1,0 +1,62 @@
+/**
+ * Marker for a value that cannot be computed yet at construction time —
+ * e.g. an attribute of a Resource that will only exist once it's actually
+ * created/deployed. `resolve()` returns the placeholder form used in the
+ * synthesized manifest (e.g. `{ ref: logicalId, attr }`), never a real value.
+ *
+ * IResolvable does NOT resolve to a real value in this package — actual
+ * resolution against deployed state is the responsibility of the future
+ * deploy engine, out of scope for @cdk-x/core.
+ */
+export interface IResolvable {
+  resolve(): unknown;
+}
+
+/**
+ * The shape of any value that can appear in a Resource's or Component's
+ * properties: plain JSON-like data, or an IResolvable placeholder anywhere
+ * within that structure (including nested inside arrays/objects).
+ */
+export type PropertyValue =
+  | string
+  | number
+  | boolean
+  | PropertyValue[]
+  | { [key: string]: PropertyValue }
+  | IResolvable;
+
+/**
+ * Static utilities for working with IResolvable values.
+ * Not instantiable — mirrors the static-only utility class pattern used
+ * elsewhere in the package (Stack.of(), Resource.of()).
+ */
+export class Resolvable {
+  private constructor() {} // no instances — static-only class
+
+  /**
+   * Runtime type guard for IResolvable. Needed because PropertyValue's shape
+   * is only known at the type level — anything walking raw props at runtime
+   * (e.g. synth()'s dependency inference) needs this to distinguish a
+   * resolvable placeholder from a plain object that happens to have the same
+   * shape.
+   *
+   * @param value - any value found while walking a Resource's or Component's
+   * properties, of unknown shape.
+   * @returns true if `value` is an object exposing a callable `resolve()`
+   * method, narrowing its type to IResolvable.
+   * @example
+   * ```ts
+   * const props = { name: 'bucket', arn: someLazyValue };
+   * if (Resolvable.isResolvable(props.arn)) {
+   *   // props.arn is now typed as IResolvable
+   * }
+   * ```
+   */
+  public static isResolvable(value: unknown): value is IResolvable {
+    return (
+      typeof value === 'object' &&
+      value !== null &&
+      typeof (value as { resolve?: unknown }).resolve === 'function'
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Add the `IResolvable` marker interface and `PropertyValue` type (plain data or an `IResolvable` placeholder anywhere in the structure) — the base primitive that `resource.ts`, `component.ts`, `stack.ts`, and `app.ts` will build on.
- Add `Resolvable.isResolvable()`, a runtime type guard needed because `PropertyValue`'s shape only exists at the type level (e.g. for `synth()`'s future dependency inference).
- Document the module-per-folder layout (`src/lib/<name>/` with a co-located spec), the OOP-first convention, and jsii-oriented JSDoc requirements in `AGENTS.md`.
- Allow private constructors in the `@typescript-eslint/no-empty-function` rule, since static-only utility classes intentionally use an empty private constructor to block instantiation.

## Test plan
- [x] `pnpm nx test core` — 11 tests pass
- [x] `pnpm nx lint core` — no errors
- [x] `pnpm nx typecheck core` — passes, confirming the `@ts-expect-error` on `new Resolvable()` is real (private constructor enforced)