### PR TITLE
feat(core): add App, Stack, Resource, and Component base classes

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,2 +1,3 @@
+export * from './lib/app/app.js';
 export * from './lib/core.js';
 export * from './lib/resolvable/resolvable.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 export * from './lib/app/app.js';
+export * from './lib/component/component.js';
 export * from './lib/core.js';
 export * from './lib/resolvable/resolvable.js';
 export * from './lib/resource/resource.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,5 @@
 export * from './lib/app/app.js';
 export * from './lib/core.js';
 export * from './lib/resolvable/resolvable.js';
+export * from './lib/resource/resource.js';
+export * from './lib/stack/stack.js';

--- a/packages/core/src/lib/app/app.spec.ts
+++ b/packages/core/src/lib/app/app.spec.ts
@@ -1,0 +1,24 @@
+import { App } from './app.js';
+
+describe('App', () => {
+  it('creates an App instance with the default outdir when no props are given', () => {
+    const app = new App();
+    expect(app.outdir).toBe('cdkx.out');
+  });
+
+  it('creates an App instance with the outdir from props when provided', () => {
+    const app = new App({ outdir: 'custom.out' });
+    expect(app.outdir).toBe('custom.out');
+  });
+
+  describe('isApp', () => {
+    it('returns true for an App instance', () => {
+      const app = new App();
+      expect(App.isApp(app)).toBe(true);
+    });
+
+    it('returns false for a non-App value', () => {
+      expect(App.isApp({})).toBe(false);
+    });
+  });
+});

--- a/packages/core/src/lib/app/app.ts
+++ b/packages/core/src/lib/app/app.ts
@@ -1,0 +1,53 @@
+import { RootConstruct } from 'constructs';
+
+/**
+ * Configuration for an {@link App}.
+ */
+export interface AppProps {
+  /**
+   * The directory to which synthesized output is written.
+   *
+   * @default 'cdkx.out'
+   */
+  readonly outdir?: string;
+}
+
+/**
+ * The root of a cdkx construct tree. Every Stack must ultimately be scoped
+ * under an App.
+ */
+export class App extends RootConstruct {
+  /**
+   * Type guard for App.
+   *
+   * @param x - the value to test.
+   * @returns true if `x` is an App, narrowing its type.
+   * @example
+   * ```ts
+   * if (App.isApp(scope)) {
+   *   // scope is now typed as App
+   * }
+   * ```
+   */
+  public static isApp(x: unknown): x is App {
+    return x instanceof App;
+  }
+
+  public readonly outdir: string;
+
+  /**
+   * @param props - configuration for this App.
+   */
+  constructor(props: AppProps = {}) {
+    super();
+    this.outdir = props.outdir ?? 'cdkx.out';
+  }
+
+  /**
+   * Synthesizes the construct tree into deployable output.
+   * Not implemented yet — lands once Stack/Resource/Component all exist.
+   */
+  public synth(): never {
+    throw new Error('App.synth() is not implemented yet.');
+  }
+}

--- a/packages/core/src/lib/component/component.spec.ts
+++ b/packages/core/src/lib/component/component.spec.ts
@@ -1,0 +1,82 @@
+import { Construct } from 'constructs';
+import { App } from '../app/app.js';
+import type { PropertyValue } from '../resolvable/resolvable.js';
+import { Resource } from '../resource/resource.js';
+import { Stack } from '../stack/stack.js';
+import { Component } from './component.js';
+
+class DummyComponent extends Component {}
+
+class DummyResource extends Resource {
+  public readonly type = 'Dummy::Resource';
+
+  protected toProperties(): Record<string, PropertyValue> {
+    return {};
+  }
+}
+
+describe('Component', () => {
+  describe('containment', () => {
+    it('constructs without error when its direct parent is a Resource', () => {
+      const app = new App();
+      const stack = new Stack(app, 'Stack');
+      const resource = new DummyResource(stack, 'Resource');
+
+      expect(() => new DummyComponent(resource, 'Component')).not.toThrow();
+    });
+
+    it('constructs without error through intermediate plain Constructs before reaching a Resource', () => {
+      const app = new App();
+      const stack = new Stack(app, 'Stack');
+      const resource = new DummyResource(stack, 'Resource');
+      const organizational = new Construct(resource, 'Organizational');
+
+      expect(
+        () => new DummyComponent(organizational, 'Component'),
+      ).not.toThrow();
+    });
+
+    it('constructs without error when nested inside another Component that descends from a Resource', () => {
+      const app = new App();
+      const stack = new Stack(app, 'Stack');
+      const resource = new DummyResource(stack, 'Resource');
+      const play = new DummyComponent(resource, 'Play');
+
+      expect(() => new DummyComponent(play, 'Task')).not.toThrow();
+    });
+
+    it('throws when constructed directly inside a Stack', () => {
+      const app = new App();
+      const stack = new Stack(app, 'Stack');
+
+      expect(() => new DummyComponent(stack, 'Component')).toThrow(
+        /must descend from a Resource/,
+      );
+    });
+
+    it('throws when constructed under a plain Construct that hangs directly off a Stack', () => {
+      const app = new App();
+      const stack = new Stack(app, 'Stack');
+      const organizational = new Construct(stack, 'Organizational');
+
+      expect(() => new DummyComponent(organizational, 'Component')).toThrow(
+        /must descend from a Resource/,
+      );
+    });
+  });
+
+  describe('isComponent', () => {
+    it('returns true for a Component instance', () => {
+      const app = new App();
+      const stack = new Stack(app, 'Stack');
+      const resource = new DummyResource(stack, 'Resource');
+      const component = new DummyComponent(resource, 'Component');
+
+      expect(Component.isComponent(component)).toBe(true);
+    });
+
+    it('returns false for a non-Component value', () => {
+      expect(Component.isComponent({})).toBe(false);
+    });
+  });
+});

--- a/packages/core/src/lib/component/component.ts
+++ b/packages/core/src/lib/component/component.ts
@@ -1,0 +1,52 @@
+import { Construct } from 'constructs';
+import { AncestorWalker } from '../../internal/ancestors.js';
+import { Resource } from '../resource/resource.js';
+import { Stack } from '../stack/stack.js';
+
+/**
+ * Base class for structural, non-deployable pieces of a Resource's shape
+ * (e.g. a Step inside a Job, a Task inside an Ansible Play). A Component
+ * has no lifecycle of its own and never gets its own manifest entry — it
+ * must always descend, directly or indirectly, from a Resource before
+ * reaching a Stack.
+ */
+export abstract class Component extends Construct {
+  /**
+   * Type guard for Component.
+   *
+   * @param x - the value to test.
+   * @returns true if `x` is a Component, narrowing its type.
+   * @example
+   * ```ts
+   * if (Component.isComponent(construct)) {
+   *   // construct is now typed as Component
+   * }
+   * ```
+   */
+  public static isComponent(x: unknown): x is Component {
+    return x instanceof Component;
+  }
+
+  /**
+   * @param scope - the construct this Component is defined within. Must
+   * descend, directly or indirectly, from a Resource before reaching a
+   * Stack — intermediate plain organizational Constructs are transparent
+   * to this check.
+   * @param id - the scoped construct ID.
+   */
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    const ownerResource = AncestorWalker.findNearest(
+      this,
+      Resource.isResource,
+      Stack.isStack,
+    );
+    if (!ownerResource) {
+      throw new Error(
+        `Component '${this.node.path}' must descend from a Resource before reaching a Stack. ` +
+          `A Component can never hang directly off a Stack.`,
+      );
+    }
+  }
+}

--- a/packages/core/src/lib/resource/resource.spec.ts
+++ b/packages/core/src/lib/resource/resource.spec.ts
@@ -1,0 +1,99 @@
+import { Construct } from 'constructs';
+import { App } from '../app/app.js';
+import { Resolvable } from '../resolvable/resolvable.js';
+import type { PropertyValue } from '../resolvable/resolvable.js';
+import { Stack } from '../stack/stack.js';
+import { Resource } from './resource.js';
+
+class DummyResource extends Resource {
+  public readonly type = 'Dummy::Resource';
+
+  protected toProperties(): Record<string, PropertyValue> {
+    return {};
+  }
+}
+
+describe('Resource', () => {
+  describe('getAtt', () => {
+    it('returns a value that satisfies Resolvable.isResolvable', () => {
+      const app = new App();
+      const stack = new Stack(app, 'Stack');
+      const resource = new DummyResource(stack, 'Resource');
+
+      expect(Resolvable.isResolvable(resource.getAtt('x'))).toBe(true);
+    });
+
+    it('resolves to an object referencing the resource path and the attribute name', () => {
+      const app = new App();
+      const stack = new Stack(app, 'Stack');
+      const resource = new DummyResource(stack, 'Resource');
+
+      expect(resource.getAtt('x').resolve()).toEqual({
+        ref: resource.node.path,
+        attr: 'x',
+      });
+    });
+  });
+
+  describe('nesting prevention', () => {
+    it('throws when a Resource is constructed directly inside another Resource', () => {
+      const app = new App();
+      const stack = new Stack(app, 'Stack');
+      const parent = new DummyResource(stack, 'Parent');
+
+      expect(() => new DummyResource(parent, 'Child')).toThrow(
+        /cannot be nested/,
+      );
+    });
+
+    it('throws when a Resource is nested inside another Resource through an intermediate plain Construct', () => {
+      const app = new App();
+      const stack = new Stack(app, 'Stack');
+      const parent = new DummyResource(stack, 'Parent');
+      const organizational = new Construct(parent, 'Organizational');
+
+      expect(() => new DummyResource(organizational, 'Child')).toThrow(
+        /cannot be nested/,
+      );
+    });
+  });
+
+  describe('addDependency', () => {
+    it('adds the target to node.dependencies when both resources belong to the same Stack', () => {
+      const app = new App();
+      const stack = new Stack(app, 'Stack');
+      const a = new DummyResource(stack, 'A');
+      const b = new DummyResource(stack, 'B');
+
+      a.addDependency(b);
+
+      expect(a.node.dependencies).toContain(b);
+    });
+
+    it('throws when the target Resource belongs to a different Stack', () => {
+      const app = new App();
+      const stackA = new Stack(app, 'StackA');
+      const stackB = new Stack(app, 'StackB');
+      const a = new DummyResource(stackA, 'A');
+      const b = new DummyResource(stackB, 'B');
+
+      expect(() => a.addDependency(b)).toThrow(/Cross-stack dependencies/);
+    });
+  });
+
+  describe('of', () => {
+    it('returns the resource itself when called on a Resource instance', () => {
+      const app = new App();
+      const stack = new Stack(app, 'Stack');
+      const resource = new DummyResource(stack, 'Resource');
+
+      expect(Resource.of(resource)).toBe(resource);
+    });
+  });
+
+  describe('isResource', () => {
+    it('returns false for a non-Resource value', () => {
+      expect(Resource.isResource({})).toBe(false);
+    });
+  });
+});

--- a/packages/core/src/lib/resource/resource.ts
+++ b/packages/core/src/lib/resource/resource.ts
@@ -1,0 +1,141 @@
+import { Construct, IConstruct } from 'constructs';
+import { AncestorWalker } from '../../internal/ancestors.js';
+import type { IResolvable, PropertyValue } from '../resolvable/resolvable.js';
+import { Stack } from '../stack/stack.js';
+
+// Module-private placeholder returned by Resource.getAtt() — resolves to the
+// synthesized-manifest reference form, never a real deployed value.
+class ResourceAttribute implements IResolvable {
+  constructor(
+    private readonly logicalId: string,
+    private readonly attr: string,
+  ) {}
+
+  resolve(): unknown {
+    return { ref: this.logicalId, attr: this.attr };
+  }
+}
+
+/**
+ * Base class for anything that synthesizes into a deployable unit. Resources
+ * must be siblings under the same Stack — connected via addDependency(),
+ * never nested inside one another.
+ */
+export abstract class Resource extends Construct {
+  /**
+   * Type guard for Resource.
+   *
+   * @param x - the value to test.
+   * @returns true if `x` is a Resource, narrowing its type.
+   * @example
+   * ```ts
+   * if (Resource.isResource(construct)) {
+   *   // construct is now typed as Resource
+   * }
+   * ```
+   */
+  public static isResource(x: unknown): x is Resource {
+    return x instanceof Resource;
+  }
+
+  /**
+   * Resolves the nearest Resource for a given construct — itself, if it
+   * already is one, otherwise its nearest Resource ancestor (stopping at
+   * the Stack boundary). Used by synth() to resolve dependencies declared
+   * on a Component to the Resource that actually owns it.
+   *
+   * @param construct - the construct to resolve the owning Resource for.
+   * @returns the owning Resource.
+   * @example
+   * ```ts
+   * const resource = Resource.of(someComponent);
+   * ```
+   */
+  public static of(construct: IConstruct): Resource {
+    if (Resource.isResource(construct)) return construct;
+    const found = AncestorWalker.findNearest(
+      construct,
+      Resource.isResource,
+      Stack.isStack,
+    );
+    if (!found) {
+      throw new Error(
+        `No Resource found for construct at path '${construct.node.path}'. ` +
+          `Make sure it descends from a Resource.`,
+      );
+    }
+    return found;
+  }
+
+  /**
+   * The resource type identifier, e.g. a CloudFormation-style type name.
+   */
+  public abstract readonly type: string;
+
+  /**
+   * @param scope - the construct this Resource is defined within.
+   * @param id - the scoped construct ID.
+   */
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    const parentResource = AncestorWalker.findNearest(
+      this,
+      Resource.isResource,
+      Stack.isStack,
+    );
+    if (parentResource) {
+      throw new Error(
+        `Resource '${this.node.path}' cannot be nested inside another Resource ` +
+          `('${parentResource.node.path}'). Resources must be siblings under the same Stack, ` +
+          `connected via addDependency(), not nesting.`,
+      );
+    }
+  }
+
+  /**
+   * Returns a lazy reference to one of this Resource's runtime attributes.
+   *
+   * @param attr - the attribute name.
+   * @returns an IResolvable that resolves to the synthesized reference form.
+   * @example
+   * ```ts
+   * const arn = bucket.getAtt('arn');
+   * ```
+   */
+  public getAtt(attr: string): IResolvable {
+    return new ResourceAttribute(this.node.path, attr);
+  }
+
+  /**
+   * Typed convenience wrapper over constructs' own node.addDependency().
+   * Only accepts another Resource (by type) — enforces the cross-stack
+   * veto here. Dependencies declared on a Component via the raw
+   * node.addDependency() API are resolved to their owning Resource later,
+   * in synth() (see Resource.of()), not here.
+   *
+   * @param target - the Resource this Resource depends on. Must belong to
+   * the same Stack.
+   */
+  public addDependency(target: Resource): void {
+    const myStack = Stack.of(this);
+    const targetStack = Stack.of(target);
+    if (myStack !== targetStack) {
+      throw new Error(
+        `Cannot add dependency: '${this.node.path}' (Stack '${myStack.node.path}') ` +
+          `cannot depend on '${target.node.path}' (Stack '${targetStack.node.path}'). ` +
+          `Cross-stack dependencies are not supported yet — move both to the same Stack.`,
+      );
+    }
+    this.node.addDependency(target);
+  }
+
+  /**
+   * Returns this Resource's own properties, serialized. Subclasses are
+   * responsible for walking their own `node.children` to collect and
+   * inline any Component descendants under whatever property key makes
+   * sense for their output format (e.g. Steps under "steps") — core has
+   * no opinion on this.
+   */
+  protected abstract toProperties(): Record<string, PropertyValue>;
+}

--- a/packages/core/src/lib/stack/stack.spec.ts
+++ b/packages/core/src/lib/stack/stack.spec.ts
@@ -1,0 +1,73 @@
+import { Construct } from 'constructs';
+import { App } from '../app/app.js';
+import { Resource } from '../resource/resource.js';
+import type { PropertyValue } from '../resolvable/resolvable.js';
+import { Stack } from './stack.js';
+
+class DummyResource extends Resource {
+  public readonly type = 'Dummy::Resource';
+
+  protected toProperties(): Record<string, PropertyValue> {
+    return {};
+  }
+}
+
+describe('Stack', () => {
+  it('can be constructed as a child of an App', () => {
+    const app = new App();
+    const stack = new Stack(app, 'Stack');
+
+    expect(stack.node.scope).toBe(app);
+  });
+
+  describe('of', () => {
+    it('returns the stack itself when called directly on a Stack instance', () => {
+      const app = new App();
+      const stack = new Stack(app, 'Stack');
+
+      expect(Stack.of(stack)).toBe(stack);
+    });
+
+    it('returns the owning stack when called on a descendant Resource', () => {
+      const app = new App();
+      const stack = new Stack(app, 'Stack');
+      const resource = new DummyResource(stack, 'Resource');
+
+      expect(Stack.of(resource)).toBe(stack);
+    });
+
+    it('throws when the construct has no Stack ancestor', () => {
+      const app = new App();
+
+      expect(() => Stack.of(app)).toThrow(/No Stack found/);
+    });
+  });
+
+  describe('isStack', () => {
+    it('returns false for a non-Stack value', () => {
+      expect(Stack.isStack({})).toBe(false);
+    });
+  });
+
+  describe('getResources', () => {
+    it('returns all descendant Resources, including those nested under intermediate plain Constructs', () => {
+      const app = new App();
+      const stack = new Stack(app, 'Stack');
+      const direct = new DummyResource(stack, 'Direct');
+      const organizational = new Construct(stack, 'Organizational');
+      const nested = new DummyResource(organizational, 'Nested');
+
+      expect(stack.getResources()).toEqual(
+        expect.arrayContaining([direct, nested]),
+      );
+    });
+
+    it('excludes descendants that are not Resources', () => {
+      const app = new App();
+      const stack = new Stack(app, 'Stack');
+      new Construct(stack, 'Organizational');
+
+      expect(stack.getResources()).toEqual([]);
+    });
+  });
+});

--- a/packages/core/src/lib/stack/stack.ts
+++ b/packages/core/src/lib/stack/stack.ts
@@ -1,0 +1,74 @@
+import { Construct, IConstruct } from 'constructs';
+import type { App } from '../app/app.js';
+import { Resource } from '../resource/resource.js';
+
+/**
+ * A deployable unit of the construct tree. Resources live directly under a
+ * Stack (possibly through intermediate organizational Constructs), never
+ * nested inside one another.
+ */
+export class Stack extends Construct {
+  /**
+   * Type guard for Stack.
+   *
+   * @param x - the value to test.
+   * @returns true if `x` is a Stack, narrowing its type.
+   * @example
+   * ```ts
+   * if (Stack.isStack(scope)) {
+   *   // scope is now typed as Stack
+   * }
+   * ```
+   */
+  public static isStack(x: unknown): x is Stack {
+    return x instanceof Stack;
+  }
+
+  /**
+   * Resolves the Stack that owns a given construct — itself, if it already
+   * is a Stack, otherwise its nearest Stack ancestor.
+   *
+   * This intentionally does not reuse `AncestorWalker.findNearest()`: that
+   * helper's contract deliberately excludes the starting construct from
+   * consideration, but `Stack.of()` must treat the starting construct as a
+   * valid result when it is already a Stack (self-inclusive) — a shape that
+   * doesn't fit `findNearest`'s generic contract, so it gets its own short
+   * loop instead.
+   *
+   * @param construct - the construct to resolve the owning Stack for.
+   * @returns the owning Stack.
+   * @example
+   * ```ts
+   * const stack = Stack.of(someResource);
+   * ```
+   */
+  public static of(construct: IConstruct): Stack {
+    if (Stack.isStack(construct)) return construct;
+    let current: IConstruct | undefined = construct.node.scope as
+      IConstruct | undefined;
+    while (current) {
+      if (Stack.isStack(current)) return current;
+      current = current.node.scope as IConstruct | undefined;
+    }
+    throw new Error(
+      `No Stack found for construct at path '${construct.node.path}'. ` +
+        `Make sure it descends from a Stack.`,
+    );
+  }
+
+  /**
+   * @param scope - the App this Stack belongs to.
+   * @param id - the scoped construct ID.
+   */
+  constructor(scope: App, id: string) {
+    super(scope, id);
+  }
+
+  /**
+   * Returns all Resources descending from this Stack, including those
+   * nested under intermediate organizational Constructs.
+   */
+  public getResources(): Resource[] {
+    return this.node.findAll().filter(Resource.isResource);
+  }
+}


### PR DESCRIPTION
## Summary
- Add `App` root construct with its spec
- Add `Resource` and `Stack` base classes with specs
- Add `Component` base class with its spec

## Context
Re-targets the work originally submitted in #121, which was merged against `main` by mistake — `feature/app-stack-resource` branches off `next` (after #118/#119/#120), so `next` is its correct base. `main` has since been restored to its pre-#121 state.