### PR TITLE
feat(core): compile to Python, Java, .NET and Go via jsii

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 
 # compiled output
 dist
+dist-jsii
+.jsii
+tsconfig.jsii.json
 tmp
 out-tsc
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Jump to the Cloud
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
     "jest": "~30.3.0",
     "jest-environment-node": "~30.3.0",
     "jest-util": "~30.3.0",
+    "jsii": "^6.0.7",
+    "jsii-pacmak": "^1.139.0",
+    "jsii-rosetta": "^6.0.7",
     "jsonc-eslint-parser": "^2.1.0",
     "nx": "23.1.0",
     "prettier": "^3.8.1",
@@ -33,7 +36,6 @@
     "typescript-eslint": "^8.58.0",
     "verdaccio": "^6.3.2"
   },
-  "dependencies": {},
   "nx": {
     "includedScripts": [],
     "targets": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,6 +30,11 @@
     "directory": "packages/core"
   },
   "license": "MIT",
+  "keywords": [
+    "cdkx",
+    "cdk",
+    "constructs"
+  ],
   "dependencies": {
     "@swc/helpers": "~0.5.18",
     "constructs": "^10.8.0"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,6 +2,7 @@
   "name": "@cdk-x/core",
   "version": "0.0.1",
   "type": "module",
+  "description": "Core constructs (App, Stack, Resource, Component) for the cdkx framework.",
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -16,10 +17,65 @@
   },
   "files": [
     "dist",
+    ".jsii",
     "!**/*.tsbuildinfo"
   ],
+  "author": {
+    "name": "cdk-x",
+    "organization": true
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cdk-x/cdkx.git",
+    "directory": "packages/core"
+  },
+  "license": "MIT",
   "dependencies": {
     "@swc/helpers": "~0.5.18",
     "constructs": "^10.8.0"
+  },
+  "peerDependencies": {
+    "constructs": "^10.8.0"
+  },
+  "devDependencies": {
+    "constructs": "10.8.0"
+  },
+  "bundledDependencies": [
+    "@swc/helpers"
+  ],
+  "jsii": {
+    "outdir": "dist-jsii",
+    "excludeTypescript": [
+      "src/**/*.spec.ts",
+      "src/**/*.test.ts"
+    ],
+    "targets": {
+      "java": {
+        "package": "com.cdkx.core",
+        "maven": {
+          "groupId": "com.cdk-x",
+          "artifactId": "cdkx-core"
+        }
+      },
+      "python": {
+        "distName": "cdkx-core",
+        "module": "cdkx.core"
+      },
+      "dotnet": {
+        "namespace": "CdkX.Core",
+        "packageId": "CdkX.Core"
+      },
+      "go": {
+        "moduleName": "github.com/cdk-x/cdkx-go"
+      }
+    },
+    "tsc": {
+      "rootDir": "src",
+      "outDir": "dist",
+      "forceConsistentCasingInFileNames": true,
+      "types": [
+        "node"
+      ]
+    }
   }
 }

--- a/packages/core/project.json
+++ b/packages/core/project.json
@@ -15,6 +15,70 @@
         "skipTypeCheck": true,
         "stripLeadingPaths": true
       }
+    },
+    "jsii-compile": {
+      "executor": "nx:run-commands",
+      "dependsOn": ["^jsii-compile"],
+      "outputs": ["{projectRoot}/dist", "{projectRoot}/.jsii"],
+      "options": {
+        "cwd": "packages/core",
+        "command": "jsii --generate-tsconfig tsconfig.jsii.json"
+      }
+    },
+    "jsii-package-npm": {
+      "executor": "nx:run-commands",
+      "dependsOn": ["jsii-compile"],
+      "outputs": ["{projectRoot}/dist-jsii/js"],
+      "options": {
+        "cwd": "packages/core",
+        "command": "jsii-pacmak -t js --outdir dist-jsii ."
+      }
+    },
+    "jsii-package-python": {
+      "executor": "nx:run-commands",
+      "dependsOn": ["jsii-compile"],
+      "outputs": ["{projectRoot}/dist-jsii/python"],
+      "options": {
+        "cwd": "packages/core",
+        "command": "jsii-pacmak -t python --outdir dist-jsii ."
+      }
+    },
+    "jsii-package-java": {
+      "executor": "nx:run-commands",
+      "dependsOn": ["jsii-compile", "^jsii-package-java"],
+      "outputs": ["{projectRoot}/dist-jsii/java"],
+      "options": {
+        "cwd": "packages/core",
+        "command": "jsii-pacmak -t java --outdir dist-jsii ."
+      }
+    },
+    "jsii-package-dotnet": {
+      "executor": "nx:run-commands",
+      "dependsOn": ["jsii-compile", "^jsii-package-dotnet"],
+      "outputs": ["{projectRoot}/dist-jsii/dotnet"],
+      "options": {
+        "cwd": "packages/core",
+        "command": "jsii-pacmak -t dotnet --outdir dist-jsii ."
+      }
+    },
+    "jsii-package-go": {
+      "executor": "nx:run-commands",
+      "dependsOn": ["jsii-compile", "^jsii-package-go"],
+      "outputs": ["{projectRoot}/dist-jsii/go"],
+      "options": {
+        "cwd": "packages/core",
+        "command": "jsii-pacmak -t go --outdir dist-jsii ."
+      }
+    },
+    "jsii-package-all": {
+      "executor": "nx:noop",
+      "dependsOn": [
+        "jsii-package-npm",
+        "jsii-package-python",
+        "jsii-package-java",
+        "jsii-package-dotnet",
+        "jsii-package-go"
+      ]
     }
   }
 }

--- a/packages/core/src/internal/ancestors.ts
+++ b/packages/core/src/internal/ancestors.ts
@@ -31,13 +31,11 @@ export class AncestorWalker {
    * @returns the nearest matching ancestor, or `undefined` if none is
    * found before a `stopAt` boundary or the root.
    * @example
-   * ```ts
    * const nearestResource = AncestorWalker.findNearest(
    *   component,
    *   (c): c is Resource => c instanceof Resource,
    *   (c) => c instanceof Stack,
    * );
-   * ```
    */
   public static findNearest<T extends IConstruct>(
     construct: IConstruct,

--- a/packages/core/src/lib/app/app.ts
+++ b/packages/core/src/lib/app/app.ts
@@ -1,5 +1,5 @@
 import { RootConstruct } from 'constructs';
-import type { Manifest } from '../synth/synth.js';
+import type { ManifestEntry } from '../synth/synth.js';
 import { Synthesizer } from '../synth/synth.js';
 
 /**
@@ -25,11 +25,9 @@ export class App extends RootConstruct {
    * @param x - the value to test.
    * @returns true if `x` is an App, narrowing its type.
    * @example
-   * ```ts
    * if (App.isApp(scope)) {
    *   // scope is now typed as App
    * }
-   * ```
    */
   public static isApp(x: unknown): x is App {
     return x instanceof App;
@@ -46,12 +44,12 @@ export class App extends RootConstruct {
   }
 
   /**
-   * Synthesizes the construct tree into deployable output — one Manifest
+   * Synthesizes the construct tree into deployable output — one manifest
    * per Stack, keyed by Stack id.
    *
    * @returns the synthesized manifests, keyed by Stack id.
    */
-  public synth(): Record<string, Manifest> {
+  public synth(): Record<string, Record<string, ManifestEntry>> {
     return Synthesizer.synthesize(this);
   }
 }

--- a/packages/core/src/lib/component/component.spec.ts
+++ b/packages/core/src/lib/component/component.spec.ts
@@ -1,6 +1,5 @@
 import { Construct } from 'constructs';
 import { App } from '../app/app.js';
-import type { PropertyValue } from '../resolvable/resolvable.js';
 import { Resource } from '../resource/resource.js';
 import { Stack } from '../stack/stack.js';
 import { Component } from './component.js';
@@ -10,7 +9,7 @@ class DummyComponent extends Component {}
 class DummyResource extends Resource {
   public readonly type = 'Dummy::Resource';
 
-  protected toProperties(): Record<string, PropertyValue> {
+  protected toProperties(): Record<string, any> {
     return {};
   }
 }

--- a/packages/core/src/lib/component/component.ts
+++ b/packages/core/src/lib/component/component.ts
@@ -17,11 +17,9 @@ export abstract class Component extends Construct {
    * @param x - the value to test.
    * @returns true if `x` is a Component, narrowing its type.
    * @example
-   * ```ts
    * if (Component.isComponent(construct)) {
    *   // construct is now typed as Component
    * }
-   * ```
    */
   public static isComponent(x: unknown): x is Component {
     return x instanceof Component;

--- a/packages/core/src/lib/resolvable/resolvable.spec.ts
+++ b/packages/core/src/lib/resolvable/resolvable.spec.ts
@@ -1,5 +1,5 @@
 import { Resolvable } from './resolvable.js';
-import type { IResolvable, PropertyValue } from './resolvable.js';
+import type { IResolvable } from './resolvable.js';
 
 describe('Resolvable', () => {
   describe('isResolvable', () => {
@@ -44,10 +44,10 @@ describe('Resolvable', () => {
       expect(instance).toBeInstanceOf(Resolvable);
     });
 
-    it('accepts an IResolvable nested anywhere within a PropertyValue', () => {
+    it('accepts an IResolvable nested anywhere within an arbitrary properties tree', () => {
       const resolvable: IResolvable = { resolve: () => 'resolved' };
 
-      const value: PropertyValue = {
+      const value: any = {
         name: 'example',
         count: 1,
         enabled: true,

--- a/packages/core/src/lib/resolvable/resolvable.ts
+++ b/packages/core/src/lib/resolvable/resolvable.ts
@@ -13,19 +13,6 @@ export interface IResolvable {
 }
 
 /**
- * The shape of any value that can appear in a Resource's or Component's
- * properties: plain JSON-like data, or an IResolvable placeholder anywhere
- * within that structure (including nested inside arrays/objects).
- */
-export type PropertyValue =
-  | string
-  | number
-  | boolean
-  | PropertyValue[]
-  | { [key: string]: PropertyValue }
-  | IResolvable;
-
-/**
  * Static utilities for working with IResolvable values.
  * Not instantiable — mirrors the static-only utility class pattern used
  * elsewhere in the package (Stack.of(), Resource.of()).
@@ -34,23 +21,21 @@ export class Resolvable {
   private constructor() {} // no instances — static-only class
 
   /**
-   * Runtime type guard for IResolvable. Needed because PropertyValue's shape
-   * is only known at the type level — anything walking raw props at runtime
-   * (e.g. synth()'s dependency inference) needs this to distinguish a
-   * resolvable placeholder from a plain object that happens to have the same
-   * shape.
+   * Runtime type guard for IResolvable. Needed because a Resource's or
+   * Component's raw property values are only known as `any` at the type
+   * level — anything walking them at runtime (e.g. synth()'s dependency
+   * inference) needs this to distinguish a resolvable placeholder from a
+   * plain object that happens to have the same shape.
    *
    * @param value - any value found while walking a Resource's or Component's
    * properties, of unknown shape.
    * @returns true if `value` is an object exposing a callable `resolve()`
    * method, narrowing its type to IResolvable.
    * @example
-   * ```ts
    * const props = { name: 'bucket', arn: someLazyValue };
    * if (Resolvable.isResolvable(props.arn)) {
    *   // props.arn is now typed as IResolvable
    * }
-   * ```
    */
   public static isResolvable(value: unknown): value is IResolvable {
     return (

--- a/packages/core/src/lib/resource/resource.spec.ts
+++ b/packages/core/src/lib/resource/resource.spec.ts
@@ -1,14 +1,13 @@
 import { Construct } from 'constructs';
 import { App } from '../app/app.js';
 import { Resolvable } from '../resolvable/resolvable.js';
-import type { PropertyValue } from '../resolvable/resolvable.js';
 import { Stack } from '../stack/stack.js';
 import { Resource } from './resource.js';
 
 class DummyResource extends Resource {
   public readonly type = 'Dummy::Resource';
 
-  protected toProperties(): Record<string, PropertyValue> {
+  protected toProperties(): Record<string, any> {
     return {};
   }
 }

--- a/packages/core/src/lib/resource/resource.ts
+++ b/packages/core/src/lib/resource/resource.ts
@@ -1,6 +1,6 @@
 import { Construct, IConstruct } from 'constructs';
 import { AncestorWalker } from '../../internal/ancestors.js';
-import type { IResolvable, PropertyValue } from '../resolvable/resolvable.js';
+import type { IResolvable } from '../resolvable/resolvable.js';
 import { Stack } from '../stack/stack.js';
 
 // Module-private placeholder returned by Resource.getAtt() — resolves to the
@@ -28,11 +28,9 @@ export abstract class Resource extends Construct {
    * @param x - the value to test.
    * @returns true if `x` is a Resource, narrowing its type.
    * @example
-   * ```ts
    * if (Resource.isResource(construct)) {
    *   // construct is now typed as Resource
    * }
-   * ```
    */
   public static isResource(x: unknown): x is Resource {
     return x instanceof Resource;
@@ -47,9 +45,7 @@ export abstract class Resource extends Construct {
    * @param construct - the construct to resolve the owning Resource for.
    * @returns the owning Resource.
    * @example
-   * ```ts
    * const resource = Resource.of(someComponent);
-   * ```
    */
   public static of(construct: IConstruct): Resource {
     if (Resource.isResource(construct)) return construct;
@@ -99,9 +95,7 @@ export abstract class Resource extends Construct {
    * @param attr - the attribute name.
    * @returns an IResolvable that resolves to the synthesized reference form.
    * @example
-   * ```ts
    * const arn = bucket.getAtt('arn');
-   * ```
    */
   public getAtt(attr: string): IResolvable {
     return new ResourceAttribute(this.node.path, attr);
@@ -136,19 +130,24 @@ export abstract class Resource extends Construct {
    * inline any Component descendants under whatever property key makes
    * sense for their output format (e.g. Steps under "steps") — core has
    * no opinion on this.
+   *
+   * Typed as `Record<string, any>` rather than a stricter JSON-tree union:
+   * jsii cannot represent a recursive union type across its target
+   * languages (Java/.NET/Go), so `any` is the jsii-compatible convention
+   * here, mirroring how aws-cdk-lib types arbitrary resource property
+   * trees.
    */
-  protected abstract toProperties(): Record<string, PropertyValue>;
+  protected abstract toProperties(): Record<string, any>;
 
   /**
    * Internal hook used by Synthesizer to read this Resource's raw
-   * properties during App.synth(). Not part of the public API surface.
-   * Once jsii tooling is added (planned), this tag will cause the member
-   * to be stripped from generated multi-language bindings. For now, it
-   * documents intent.
+   * properties during App.synth(). Not part of the public API surface —
+   * the `@internal` tag causes this member to be stripped from generated
+   * multi-language bindings.
    *
    * @internal
    */
-  public _toProperties(): Record<string, PropertyValue> {
+  public _toProperties(): Record<string, any> {
     return this.toProperties();
   }
 }

--- a/packages/core/src/lib/stack/stack.spec.ts
+++ b/packages/core/src/lib/stack/stack.spec.ts
@@ -1,13 +1,12 @@
 import { Construct } from 'constructs';
 import { App } from '../app/app.js';
 import { Resource } from '../resource/resource.js';
-import type { PropertyValue } from '../resolvable/resolvable.js';
 import { Stack } from './stack.js';
 
 class DummyResource extends Resource {
   public readonly type = 'Dummy::Resource';
 
-  protected toProperties(): Record<string, PropertyValue> {
+  protected toProperties(): Record<string, any> {
     return {};
   }
 }
@@ -49,7 +48,7 @@ describe('Stack', () => {
     });
   });
 
-  describe('getResources', () => {
+  describe('resources', () => {
     it('returns all descendant Resources, including those nested under intermediate plain Constructs', () => {
       const app = new App();
       const stack = new Stack(app, 'Stack');
@@ -57,7 +56,7 @@ describe('Stack', () => {
       const organizational = new Construct(stack, 'Organizational');
       const nested = new DummyResource(organizational, 'Nested');
 
-      expect(stack.getResources()).toEqual(
+      expect(stack.resources()).toEqual(
         expect.arrayContaining([direct, nested]),
       );
     });
@@ -67,7 +66,7 @@ describe('Stack', () => {
       const stack = new Stack(app, 'Stack');
       new Construct(stack, 'Organizational');
 
-      expect(stack.getResources()).toEqual([]);
+      expect(stack.resources()).toEqual([]);
     });
   });
 });

--- a/packages/core/src/lib/stack/stack.ts
+++ b/packages/core/src/lib/stack/stack.ts
@@ -14,11 +14,9 @@ export class Stack extends Construct {
    * @param x - the value to test.
    * @returns true if `x` is a Stack, narrowing its type.
    * @example
-   * ```ts
    * if (Stack.isStack(scope)) {
    *   // scope is now typed as Stack
    * }
-   * ```
    */
   public static isStack(x: unknown): x is Stack {
     return x instanceof Stack;
@@ -38,9 +36,7 @@ export class Stack extends Construct {
    * @param construct - the construct to resolve the owning Stack for.
    * @returns the owning Stack.
    * @example
-   * ```ts
    * const stack = Stack.of(someResource);
-   * ```
    */
   public static of(construct: IConstruct): Stack {
     if (Stack.isStack(construct)) return construct;
@@ -68,7 +64,7 @@ export class Stack extends Construct {
    * Returns all Resources descending from this Stack, including those
    * nested under intermediate organizational Constructs.
    */
-  public getResources(): Resource[] {
+  public resources(): Resource[] {
     return this.node.findAll().filter(Resource.isResource);
   }
 }

--- a/packages/core/src/lib/synth/synth.spec.ts
+++ b/packages/core/src/lib/synth/synth.spec.ts
@@ -1,15 +1,14 @@
 import { App } from '../app/app.js';
 import { Component } from '../component/component.js';
-import type { PropertyValue } from '../resolvable/resolvable.js';
 import { Resource } from '../resource/resource.js';
 import { Stack } from '../stack/stack.js';
 import { CycleError, Synthesizer } from './synth.js';
 
 class DummyResource extends Resource {
   public readonly type = 'Dummy::Resource';
-  public properties: Record<string, PropertyValue> = {};
+  public properties: Record<string, any> = {};
 
-  protected toProperties(): Record<string, PropertyValue> {
+  protected toProperties(): Record<string, any> {
     return this.properties;
   }
 }

--- a/packages/core/src/lib/synth/synth.ts
+++ b/packages/core/src/lib/synth/synth.ts
@@ -1,11 +1,21 @@
 import type { App } from '../app/app.js';
 import { Resolvable } from '../resolvable/resolvable.js';
-import type { PropertyValue } from '../resolvable/resolvable.js';
 import { Resource } from '../resource/resource.js';
 import { Stack } from '../stack/stack.js';
 
+// JSON-tree shape used only by this file's private serialization helpers —
+// a recursive union like this can't be represented across jsii's target
+// languages, so it stays internal and never appears in an exported type.
+type PropertyValue =
+  | string
+  | number
+  | boolean
+  | PropertyValue[]
+  | { [key: string]: PropertyValue };
+
 /**
- * A single Resource's synthesized entry within a Stack's {@link Manifest}.
+ * A single Resource's synthesized entry within a Stack's synthesized
+ * manifest (see {@link Synthesizer.synthesize}).
  */
 export interface ManifestEntry {
   /**
@@ -17,7 +27,7 @@ export interface ManifestEntry {
    * This Resource's serialized properties — any IResolvable values have
    * been replaced with their resolved (placeholder) form.
    */
-  readonly properties: Record<string, PropertyValue>;
+  readonly properties: Record<string, any>;
 
   /**
    * The logical ids (Resource.node.path) of every Resource this entry
@@ -27,23 +37,44 @@ export interface ManifestEntry {
   readonly dependsOn: string[];
 }
 
-/**
- * A Stack's synthesized output: every Resource it contains, keyed by
- * logical id (`Resource.node.path`).
- */
-export type Manifest = Record<string, ManifestEntry>;
+// A Stack's synthesized output: every Resource it contains, keyed by
+// logical id (`Resource.node.path`). Kept internal (not exported) — jsii
+// wants named interfaces for exported object shapes, not bare aliases, so
+// `Synthesizer.synthesize()` below inlines `Record<string, ManifestEntry>`
+// directly instead of exporting this alias.
+type Manifest = Record<string, ManifestEntry>;
+
+// jsii flags an exported class extending the built-in Error, regardless of
+// @internal — the check runs on the class's own heritage clause before
+// internal-filtering. aws-cdk-lib's ConstructError hits the same wall and
+// works around it the same way: the class that directly extends Error stays
+// module-private (never exported), so jsii's exported-declaration scan never
+// sees it; only the subclass — extending this private base, not Error itself
+// — is exported (as @internal below).
+abstract class BaseError extends Error {
+  protected constructor(message: string) {
+    super(message);
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
 
 /**
  * Thrown by {@link Synthesizer.synthesize} when a Stack's Resources form a
- * dependency cycle.
+ * dependency cycle. Not part of the public API surface — see the
+ * {@link BaseError} note above for why. Other-language consumers still
+ * receive the error and its message when a cycle is detected, just not as a
+ * distinctly catchable, structurally-typed exception.
+ *
+ * @internal
  */
-export class CycleError extends Error {
+export class CycleError extends BaseError {
   /**
    * @param cycle - the logical ids forming the cycle, in traversal order,
    * with the first id repeated at the end to close the loop.
    */
   constructor(public readonly cycle: string[]) {
     super(`Dependency cycle detected: ${cycle.join(' -> ')}`);
+    Object.setPrototypeOf(this, CycleError.prototype);
   }
 }
 
@@ -63,11 +94,11 @@ export class Synthesizer {
    * @param app - the App to synthesize.
    * @returns a map of Stack id to that Stack's synthesized Manifest.
    * @example
-   * ```ts
    * const manifests = Synthesizer.synthesize(app);
-   * ```
    */
-  public static synthesize(app: App): Record<string, Manifest> {
+  public static synthesize(
+    app: App,
+  ): Record<string, Record<string, ManifestEntry>> {
     const stacks = app.node.children.filter(Stack.isStack);
     const resourcesByPath = new Map<string, Resource>(
       app.node
@@ -92,7 +123,7 @@ export class Synthesizer {
   ): Manifest {
     const manifest: Manifest = {};
 
-    for (const resource of stack.getResources()) {
+    for (const resource of stack.resources()) {
       const rawProps = resource._toProperties();
       manifest[resource.node.path] = {
         type: resource.type,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,15 @@ importers:
       jest-util:
         specifier: ~30.3.0
         version: 30.3.0
+      jsii:
+        specifier: ^6.0.7
+        version: 6.0.7
+      jsii-pacmak:
+        specifier: ^1.139.0
+        version: 1.139.0(jsii-rosetta@6.0.7)
+      jsii-rosetta:
+        specifier: ^6.0.7
+        version: 6.0.7
       jsonc-eslint-parser:
         specifier: ^2.1.0
         version: 2.4.2
@@ -999,6 +1008,14 @@ packages:
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
+  '@jsii/check-node@1.139.0':
+    resolution: {integrity: sha512-tLS0H2XPN3hWVO9OtVB2DDllaxz3M6Jz8Zk8ByV1pl2h5b6LayJg8lHYvRMf0b3P/82xqWat7CpfLeqU96OwVw==}
+    engines: {node: '>= 14.17.0'}
+
+  '@jsii/spec@1.139.0':
+    resolution: {integrity: sha512-+l1B0h4WAg6KOQ7PGykW/FvxeFmyt74U0/n41cus9Jdjv3VfQJKynsv5r9Ng23B1KwWqJkS5YvJuv2yGYoULdw==}
+    engines: {node: '>= 14.17.0'}
+
   '@keyv/serialize@1.1.1':
     resolution: {integrity: sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==}
 
@@ -1875,6 +1892,10 @@ packages:
     resolution: {integrity: sha512-y5ArHvQ7BVule/+L9yE2nYMhceiJhgsqo58lOfnisQ7bg+Kjfmkgr7JBuVFiTkl+ErdShpp829QstZQyLugl8g==}
     engines: {node: '>=20'}
 
+  '@xmldom/xmldom@0.9.10':
+    resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
+    engines: {node: '>=14.6'}
+
   '@yarnpkg/lockfile@1.1.0':
     resolution: {integrity: sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==}
 
@@ -2211,6 +2232,10 @@ packages:
   caniuse-lite@1.0.30001806:
     resolution: {integrity: sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==}
 
+  case@1.6.3:
+    resolution: {integrity: sha512-mzDSXIPaFwVDvZAHqZ9VlbyF4yyXRuX6IvB06WvPYkqJVO24kX1PPhv9bfpKNFZyxYFmmgo03HUiD8iklmJYRQ==}
+    engines: {node: '>= 0.8.0'}
+
   caseless@0.12.0:
     resolution: {integrity: sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==}
 
@@ -2254,9 +2279,17 @@ packages:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
     engines: {node: '>=0.8'}
 
+  clone@2.1.2:
+    resolution: {integrity: sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==}
+    engines: {node: '>=0.8'}
+
   co@4.6.0:
     resolution: {integrity: sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==}
     engines: {iojs: '>= 1.0.0', node: '>= 0.12.0'}
+
+  codemaker@1.139.0:
+    resolution: {integrity: sha512-v93CwWcepdmHDENEJuPepaOzo2J8SZ5HKNVgH/+6vPrvLOoDDfVXEkBMr6KUu4trHN7QvZjFwxJBpjCYCBG9+g==}
+    engines: {node: '>= 14.17.0'}
 
   collect-v8-coverage@1.0.3:
     resolution: {integrity: sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==}
@@ -2286,6 +2319,10 @@ packages:
   commander@8.3.0:
     resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
     engines: {node: '>= 12'}
+
+  commonmark@0.31.2:
+    resolution: {integrity: sha512-2fRLTyb9r/2835k5cwcAwOj0DEc44FARnMp5veGsJ+mEAZdi52sNopLu07ZyElQUz058H43whzlERDIaaSw4rg==}
+    hasBin: true
 
   compressible@2.0.18:
     resolution: {integrity: sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==}
@@ -2358,6 +2395,10 @@ packages:
     resolution: {integrity: sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==}
     engines: {node: '>=0.10'}
 
+  date-format@4.0.14:
+    resolution: {integrity: sha512-39BOQLs9ZjKh0/patS9nrT8wc3ioX3/eA/zgbKNopnF2wCqJEoxywwwElATYvRsXdnOxA/OQeQoFZ3rFjVajhg==}
+    engines: {node: '>=4.0'}
+
   dayjs@1.11.18:
     resolution: {integrity: sha512-zFBQ7WFRvVRhKcWoUh+ZA1g2HVgUbsZm9sbddh8EC5iv93sui8DVVz1Npvz+r6meo9VKfa8NyLWBsQK1VvIKPA==}
 
@@ -2377,6 +2418,10 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decamelize@5.0.1:
+    resolution: {integrity: sha512-VfxadyCECXgQlkoEAjeghAr5gY3Hf+IKjKb+X8tGVDtveCjN+USwprd2q3QXBR9T1+x2DG0XZF5/w+7HAtSaXA==}
+    engines: {node: '>=10'}
 
   decompress-response@10.0.0:
     resolution: {integrity: sha512-oj7KWToJuuxlPr7VV0vabvxEIiqNMo+q0NueIiL3XhtwC6FVOX7Hr1c0C4eD0bmf7Zr+S/dSf2xvkH3Ad6sU3Q==}
@@ -2415,6 +2460,14 @@ packages:
   destroy@1.2.0:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
+  detect-indent@5.0.0:
+    resolution: {integrity: sha512-rlpvsxUtM0PQvy9iZe640/IWwWYyBsTApREbA1pHOpmOUIl9MkP/U4z7vTtg4Oaojvqhxt7sdufnT0EzGaR31g==}
+    engines: {node: '>=4'}
+
+  detect-newline@2.1.0:
+    resolution: {integrity: sha512-CwffZFvlJffUg9zZA0uqrjQayUTC8ob94pnr5sFwaVv3IOmkfUHcWH+jXaQK3askE51Cqe8/9Ql/0uXNwqZ8Zg==}
+    engines: {node: '>=0.10.0'}
 
   detect-newline@3.1.0:
     resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
@@ -2488,6 +2541,10 @@ packages:
   enquirer@2.3.6:
     resolution: {integrity: sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==}
     engines: {node: '>=8.6'}
+
+  entities@3.0.1:
+    resolution: {integrity: sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==}
+    engines: {node: '>=0.12'}
 
   envinfo@7.21.0:
     resolution: {integrity: sha512-Lw7I8Zp5YKHFCXL7+Dz95g4CcbMEpgvqZNNq3AmlT5XAV6CgAAk6gyAMqn2zjw08K9BHfcNuKrMiCPLByGafow==}
@@ -2781,6 +2838,14 @@ packages:
 
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
+
+  fs-extra@10.1.0:
+    resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
+    engines: {node: '>=12'}
+
+  fs-extra@8.1.0:
+    resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
+    engines: {node: '>=6 <7 || >=8'}
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
@@ -3354,6 +3419,28 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  jsii-pacmak@1.139.0:
+    resolution: {integrity: sha512-hE+rc+RS4Qwe+MzGqG515tXueOhn6r++/L8kpX5wT18HqUoBJdOdqFOv90PYitDgNywovOE0kEd8YyV1S5Mh6Q==}
+    engines: {node: '>= 14.17.0'}
+    hasBin: true
+    peerDependencies:
+      jsii-rosetta: '>=5.9.0'
+
+  jsii-reflect@1.139.0:
+    resolution: {integrity: sha512-Z8rGDzykcg6REfFV8HJZ0oms5zi8wBO4T7B5thSS4iME0osbWJP62pFn2yT6VivOESKnkFZOI3RkIKYkynPbGg==}
+    engines: {node: '>= 14.17.0'}
+    hasBin: true
+
+  jsii-rosetta@6.0.7:
+    resolution: {integrity: sha512-zJQ3KEIArxQs5iOK41PbVkeoBchUfzV+mvgRGke/HJHLhAtOLHkQ+tl64JlF+4djSLHICTOfnPGtbz8/DIZqZA==}
+    engines: {node: '>= 20.16.0'}
+    hasBin: true
+
+  jsii@6.0.7:
+    resolution: {integrity: sha512-nrxb6K20iPJgXo2AexBshYDd+dNsBcoH1//30pNg4Hk1YLaSDVEAtbvrNg2XXTSi9bvcvuEarq9IEFGeHnC/5w==}
+    engines: {node: '>= 20.16.0'}
+    hasBin: true
+
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
@@ -3386,6 +3473,12 @@ packages:
 
   jsonc-parser@3.3.1:
     resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
+
+  jsonfile@4.0.0:
+    resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
+
+  jsonfile@6.2.1:
+    resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
 
   jsonparse@1.3.1:
     resolution: {integrity: sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==}
@@ -3478,6 +3571,10 @@ packages:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
     engines: {node: '>=10'}
 
+  log4js@6.9.1:
+    resolution: {integrity: sha512-1somDdy9sChrr9/f4UlzhdaGfDR2c/SaD2a4T7qEkG4jTS57/B3qmnjLYePwQ8cqWnUHZI0iAKxMBpCZICiZ2g==}
+    engines: {node: '>=8.0'}
+
   lowdb@1.0.0:
     resolution: {integrity: sha512-2+x8esE/Wb9SQ1F9IHaYWfsC9FIecLOPrK4g17FGEayjUWH172H6nwicRovGvSE2CPZouc2MCIqCI7h9d+GftQ==}
     engines: {node: '>=4'}
@@ -3517,6 +3614,9 @@ packages:
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mdurl@1.0.1:
+    resolution: {integrity: sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==}
 
   media-typer@0.3.0:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
@@ -3696,6 +3796,10 @@ packages:
   onetime@6.0.0:
     resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
     engines: {node: '>=12'}
+
+  oo-ascii-tree@1.139.0:
+    resolution: {integrity: sha512-Sv9334UvsBcvYh9xkcBtheWjH+mkhXLmuhOm+/OTGVFUCsvdVdXwDMTbYZHpJaTSbhaHScPbHqjAPECAFwlgtg==}
+    engines: {node: '>= 14.17.0'}
 
   open@8.4.2:
     resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
@@ -4008,6 +4112,9 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
+  rfdc@1.4.1:
+    resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -4030,6 +4137,9 @@ packages:
   seek-bzip@2.0.0:
     resolution: {integrity: sha512-SMguiTnYrhpLdk3PwfzHeotrcwi8bNV4iemL9tx9poR/yeaMYwB9VzR1w7b57DuWpuqR8n6oZboi0hj3AxZxQg==}
     hasBin: true
+
+  semver-intersect@1.5.0:
+    resolution: {integrity: sha512-BDjWX7yCC0haX4W/zrnV2JaMpVirwaEkGOBmgRQtH++F1N3xl9v7k9H44xfTqwl+yLNNSbMKosoVSTIiJVQ2Pw==}
 
   semver-regex@4.0.5:
     resolution: {integrity: sha512-hunMQrEy1T6Jr2uEVjrAIqjwWcQTgOAcIM52C8MY1EZSD3DDNft04XzvYKPqjED65bNVVko0YI38nYeEHCX3yw==}
@@ -4114,6 +4224,10 @@ packages:
   sonic-boom@4.2.1:
     resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
 
+  sort-json@2.0.1:
+    resolution: {integrity: sha512-s8cs2bcsQCzo/P2T/uoU6Js4dS/jnX8+4xunziNoq9qmSpZNCrRIAIvp4avsz0ST18HycV4z/7myJ7jsHWB2XQ==}
+    hasBin: true
+
   sort-keys-length@1.0.1:
     resolution: {integrity: sha512-GRbEOUqCxemTAk/b32F2xa8wDTs+Z1QHOkbhJDQTvv/6G3ZkbJ+frYWsTcc7cBB3Fu4wy4XlLCuNtJuMn7Gsvw==}
     engines: {node: '>=0.10.0'}
@@ -4139,6 +4253,10 @@ packages:
     resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
     engines: {node: '>= 12'}
 
+  spdx-license-list@6.12.0:
+    resolution: {integrity: sha512-+nUYqm3aZMSHbjsthK+i/HHI2okTElCvqwUd4k8QcSk+FTGgjq+fsdFj2wZOaX6XmR2JdWhf/NeflNnvKOjcnQ==}
+    engines: {node: '>=8'}
+
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
@@ -4162,8 +4280,18 @@ packages:
   steno@0.4.4:
     resolution: {integrity: sha512-EEHMVYHNXFHfGtgjNITnka0aHhiAlo93F7z2/Pwd+g0teG9CnM3JIINM7hVVB5/rhw9voufD7Wukwgtw2uqh6w==}
 
+  stream-chain@2.2.5:
+    resolution: {integrity: sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA==}
+
+  stream-json@1.9.1:
+    resolution: {integrity: sha512-uWkjJ+2Nt/LO9Z/JyKZbMusL8Dkh97uUBTv3AJQ74y07lVahLY4eEFsPsE97pxYBwr8nnjMAIch5eqI0gPShyw==}
+
   stream-shift@1.0.3:
     resolution: {integrity: sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==}
+
+  streamroller@3.1.5:
+    resolution: {integrity: sha512-KFxaM7XT+irxvdqSP1LGLgNWbYN7ay5owZ3r/8t77p+EtSUAfUgtl7be3xtqtOmGUl9K9YPO2ca8133RlTjvKw==}
+    engines: {node: '>=8.0'}
 
   streamx@2.28.0:
     resolution: {integrity: sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==}
@@ -4454,6 +4582,14 @@ packages:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
     engines: {node: '>=18'}
 
+  universalify@0.1.2:
+    resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
+    engines: {node: '>= 4.0.0'}
+
+  universalify@2.0.1:
+    resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
+    engines: {node: '>= 10.0.0'}
+
   unix-crypt-td-js@1.1.4:
     resolution: {integrity: sha512-8rMeVYWSIyccIJscb9NdCfZKSRBKYTeVnwmiRYT2ulE3qd1RaDQ0xQDP+rI3ccIWbhu/zuo5cgN8z73belNZgw==}
 
@@ -4547,6 +4683,9 @@ packages:
   wordwrap@1.0.0:
     resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
 
+  workerpool@6.5.1:
+    resolution: {integrity: sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==}
+
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
@@ -4561,6 +4700,10 @@ packages:
   write-file-atomic@5.0.1:
     resolution: {integrity: sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
+  xmlbuilder@15.1.1:
+    resolution: {integrity: sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==}
+    engines: {node: '>=8.0'}
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -4588,6 +4731,10 @@ packages:
 
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
+
+  yargs@17.7.3:
+    resolution: {integrity: sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==}
     engines: {node: '>=12'}
 
   yauzl@3.4.0:
@@ -5894,6 +6041,13 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@jsii/check-node@1.139.0':
+    dependencies:
+      chalk: 4.1.2
+      semver: 7.8.5
+
+  '@jsii/spec@1.139.0': {}
+
   '@keyv/serialize@1.1.1': {}
 
   '@napi-rs/nice-android-arm-eabi@1.1.1':
@@ -6880,6 +7034,8 @@ snapshots:
     dependencies:
       system-architecture: 1.0.0
 
+  '@xmldom/xmldom@0.9.10': {}
+
   '@yarnpkg/lockfile@1.1.0': {}
 
   '@zkochan/js-yaml@0.0.7':
@@ -7261,6 +7417,8 @@ snapshots:
 
   caniuse-lite@1.0.30001806: {}
 
+  case@1.6.3: {}
+
   caseless@0.12.0: {}
 
   chalk@4.1.2:
@@ -7294,7 +7452,15 @@ snapshots:
 
   clone@1.0.4: {}
 
+  clone@2.1.2: {}
+
   co@4.6.0: {}
+
+  codemaker@1.139.0:
+    dependencies:
+      camelcase: 6.3.0
+      decamelize: 5.0.1
+      fs-extra: 10.1.0
 
   collect-v8-coverage@1.0.3: {}
 
@@ -7318,6 +7484,12 @@ snapshots:
   commander@6.2.1: {}
 
   commander@8.3.0: {}
+
+  commonmark@0.31.2:
+    dependencies:
+      entities: 3.0.1
+      mdurl: 1.0.1
+      minimist: 1.2.8
 
   compressible@2.0.18:
     dependencies:
@@ -7390,6 +7562,8 @@ snapshots:
     dependencies:
       assert-plus: 1.0.0
 
+  date-format@4.0.14: {}
+
   dayjs@1.11.18: {}
 
   debug@2.6.9:
@@ -7401,6 +7575,8 @@ snapshots:
       ms: 2.1.3
     optionalDependencies:
       supports-color: 7.2.0
+
+  decamelize@5.0.1: {}
 
   decompress-response@10.0.0:
     dependencies:
@@ -7425,6 +7601,10 @@ snapshots:
   depd@2.0.0: {}
 
   destroy@1.2.0: {}
+
+  detect-indent@5.0.0: {}
+
+  detect-newline@2.1.0: {}
 
   detect-newline@3.1.0: {}
 
@@ -7489,6 +7669,8 @@ snapshots:
   enquirer@2.3.6:
     dependencies:
       ansi-colors: 4.1.3
+
+  entities@3.0.1: {}
 
   envinfo@7.21.0: {}
 
@@ -7882,6 +8064,18 @@ snapshots:
   fresh@0.5.2: {}
 
   fs-constants@1.0.0: {}
+
+  fs-extra@10.1.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.2.1
+      universalify: 2.0.1
+
+  fs-extra@8.1.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 4.0.0
+      universalify: 0.1.2
 
   fs.realpath@1.0.0: {}
 
@@ -8805,6 +8999,66 @@ snapshots:
 
   jsesc@3.1.0: {}
 
+  jsii-pacmak@1.139.0(jsii-rosetta@6.0.7):
+    dependencies:
+      '@jsii/check-node': 1.139.0
+      '@jsii/spec': 1.139.0
+      clone: 2.1.2
+      codemaker: 1.139.0
+      commonmark: 0.31.2
+      escape-string-regexp: 4.0.0
+      fs-extra: 10.1.0
+      jsii-reflect: 1.139.0
+      jsii-rosetta: 6.0.7
+      semver: 7.8.5
+      spdx-license-list: 6.12.0
+      xmlbuilder: 15.1.1
+      yargs: 17.7.3
+
+  jsii-reflect@1.139.0:
+    dependencies:
+      '@jsii/check-node': 1.139.0
+      '@jsii/spec': 1.139.0
+      chalk: 4.1.2
+      fs-extra: 10.1.0
+      oo-ascii-tree: 1.139.0
+      yargs: 17.7.3
+
+  jsii-rosetta@6.0.7:
+    dependencies:
+      '@jsii/check-node': 1.139.0
+      '@jsii/spec': 1.139.0
+      '@xmldom/xmldom': 0.9.10
+      chalk: 4.1.2
+      commonmark: 0.31.2
+      fast-glob: 3.3.3
+      jsii: 6.0.7
+      semver: 7.8.5
+      semver-intersect: 1.5.0
+      stream-json: 1.9.1
+      typescript: 6.0.3
+      workerpool: 6.5.1
+      yargs: 17.7.3
+    transitivePeerDependencies:
+      - supports-color
+
+  jsii@6.0.7:
+    dependencies:
+      '@jsii/check-node': 1.139.0
+      '@jsii/spec': 1.139.0
+      case: 1.6.3
+      chalk: 4.1.2
+      fast-deep-equal: 3.1.3
+      log4js: 6.9.1
+      semver: 7.8.5
+      semver-intersect: 1.5.0
+      sort-json: 2.0.1
+      spdx-license-list: 6.12.0
+      typescript: 6.0.3
+      yargs: 17.7.3
+    transitivePeerDependencies:
+      - supports-color
+
   json-buffer@3.0.1: {}
 
   json-parse-even-better-errors@2.3.1: {}
@@ -8829,6 +9083,16 @@ snapshots:
       semver: 7.8.5
 
   jsonc-parser@3.3.1: {}
+
+  jsonfile@4.0.0:
+    optionalDependencies:
+      graceful-fs: 4.2.11
+
+  jsonfile@6.2.1:
+    dependencies:
+      universalify: 2.0.1
+    optionalDependencies:
+      graceful-fs: 4.2.11
 
   jsonparse@1.3.1: {}
 
@@ -8923,6 +9187,16 @@ snapshots:
       chalk: 4.1.2
       is-unicode-supported: 0.1.0
 
+  log4js@6.9.1:
+    dependencies:
+      date-format: 4.0.14
+      debug: 4.4.3(supports-color@7.2.0)
+      flatted: 3.4.3
+      rfdc: 1.4.1
+      streamroller: 3.1.5
+    transitivePeerDependencies:
+      - supports-color
+
   lowdb@1.0.0:
     dependencies:
       graceful-fs: 4.2.11
@@ -8960,6 +9234,8 @@ snapshots:
       tmpl: 1.0.5
 
   math-intrinsics@1.1.0: {}
+
+  mdurl@1.0.1: {}
 
   media-typer@0.3.0: {}
 
@@ -9203,6 +9479,8 @@ snapshots:
   onetime@6.0.0:
     dependencies:
       mimic-fn: 4.0.0
+
+  oo-ascii-tree@1.139.0: {}
 
   open@8.4.2:
     dependencies:
@@ -9530,6 +9808,8 @@ snapshots:
 
   reusify@1.1.0: {}
 
+  rfdc@1.4.1: {}
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -9549,6 +9829,10 @@ snapshots:
   seek-bzip@2.0.0:
     dependencies:
       commander: 6.2.1
+
+  semver-intersect@1.5.0:
+    dependencies:
+      semver: 6.3.1
 
   semver-regex@4.0.5: {}
 
@@ -9643,6 +9927,12 @@ snapshots:
     dependencies:
       atomic-sleep: 1.0.0
 
+  sort-json@2.0.1:
+    dependencies:
+      detect-indent: 5.0.0
+      detect-newline: 2.1.0
+      minimist: 1.2.8
+
   sort-keys-length@1.0.1:
     dependencies:
       sort-keys: 1.1.2
@@ -9670,6 +9960,8 @@ snapshots:
 
   source-map@0.7.6: {}
 
+  spdx-license-list@6.12.0: {}
+
   split2@4.2.0: {}
 
   sprintf-js@1.0.3: {}
@@ -9696,7 +9988,21 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
 
+  stream-chain@2.2.5: {}
+
+  stream-json@1.9.1:
+    dependencies:
+      stream-chain: 2.2.5
+
   stream-shift@1.0.3: {}
+
+  streamroller@3.1.5:
+    dependencies:
+      date-format: 4.0.14
+      debug: 4.4.3(supports-color@7.2.0)
+      fs-extra: 8.1.0
+    transitivePeerDependencies:
+      - supports-color
 
   streamx@2.28.0:
     dependencies:
@@ -9983,6 +10289,10 @@ snapshots:
 
   unicorn-magic@0.3.0: {}
 
+  universalify@0.1.2: {}
+
+  universalify@2.0.1: {}
+
   unix-crypt-td-js@1.1.4: {}
 
   unpipe@1.0.0: {}
@@ -10140,6 +10450,8 @@ snapshots:
 
   wordwrap@1.0.0: {}
 
+  workerpool@6.5.1: {}
+
   wrap-ansi@7.0.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -10159,6 +10471,8 @@ snapshots:
       imurmurhash: 0.1.4
       signal-exit: 4.1.0
 
+  xmlbuilder@15.1.1: {}
+
   xtend@4.0.2: {}
 
   y18n@5.0.8: {}
@@ -10172,6 +10486,16 @@ snapshots:
   yargs-parser@21.1.1: {}
 
   yargs@17.7.2:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
+
+  yargs@17.7.3:
     dependencies:
       cliui: 8.0.1
       escalade: 3.2.0


### PR DESCRIPTION
## Summary
- Wire up `@cdk-x/core` to compile through jsii, matching the proven setup in the `cdk-x/cdk8s-catalog` sibling repo: jsii runs a second, independent compile pass directly from the existing ESM source into the same `dist/` (no separate CJS build needed), producing the `.jsii` assembly alongside the existing SWC build.
- Adjust `@cdk-x/core`'s public API for jsii compatibility: no exported recursive union types or bare type aliases, `CycleError` no longer extends `Error` directly (mirrors aws-cdk-lib's own `ConstructError` pattern), `Stack.getResources()` renamed to `Stack.resources()` (Java bean-getter naming conflict), `@example` JSDoc blocks are code-only (no fences).
- Add Nx targets `jsii-compile`, `jsii-package-npm`/`-python`/`-java`/`-dotnet`/`-go`, `jsii-package-all`, matching the reference repo's naming convention.
- Add `jsii`/`jsii-pacmak`/`jsii-rosetta` as root devDependencies, an MIT `LICENSE` file, and per-language identifiers (Java `com.cdk-x`/`com.cdkx.core`, Python `cdkx-core`/`cdkx.core`, .NET `CdkX.Core`, Go `github.com/cdk-x/cdkx-go`).

## Test plan
- [x] `pnpm nx run core:build` — existing ESM build unaffected
- [x] `pnpm nx run core:test` — 52/52 tests passing
- [x] `pnpm nx run core:typecheck` — no type errors
- [x] `pnpm nx run core:jsii-compile` — 0 errors (2 non-blocking Go reserved-word warnings on `type`)
- [x] `pnpm nx run core:jsii-package-all` — verified real artifacts generated for all 4 language targets (Maven jar under `com/cdk-x/cdkx-core`, Python wheel, NuGet package, Go module) plus the JS tarball
- [x] `pnpm nx format:check` — clean