### PR TITLE
Configure release/publish tooling with prerelease phases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,14 +14,14 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           filter: tree:0
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: 'pnpm'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,15 +4,15 @@ on:
   workflow_dispatch:
     inputs:
       projects:
-        description: "Comma/space-separated project names to release (e.g. core). Empty = all projects with pending changes."
+        description: 'Comma/space-separated project names to release (e.g. core). Empty = all projects with pending changes.'
         type: string
-        default: ""
+        default: ''
       first_release:
         description: "First release for the selected project(s): forces an explicit 1.0.0 (or 1.0.0-<phase>.0) version instead of a conventional-commits bump, and switches npm publish to a classic NPM_TOKEN instead of OIDC Trusted Publisher (which can't be configured on npm before the package exists)"
         type: boolean
         default: false
       dry_run:
-        description: "Dry run: no git push, no real publish (PUBLIB_DRYRUN=true)"
+        description: 'Dry run: no git push, no real publish (PUBLIB_DRYRUN=true)'
         type: boolean
         default: false
 
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: 24
-          cache: "pnpm"
+          cache: 'pnpm'
 
       - run: pnpm install --frozen-lockfile
 
@@ -114,16 +114,16 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: 24
-          cache: "pnpm"
+          cache: 'pnpm'
 
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: "17"
+          java-version: '17'
 
       - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: "8.x"
+          dotnet-version: '8.x'
 
       - run: pnpm install --frozen-lockfile
 
@@ -170,7 +170,7 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: 24
-          cache: "pnpm"
+          cache: 'pnpm'
 
       - run: pnpm install --frozen-lockfile
 
@@ -226,7 +226,7 @@ jobs:
     environment: pypi-${{ matrix.pkg.name }}
     env:
       PUBLIB_DRYRUN: ${{ inputs.dry_run }}
-      PYPI_TRUSTED_PUBLISHER: "1"
+      PYPI_TRUSTED_PUBLISHER: '1'
     steps:
       - uses: actions/checkout@v5
         with:
@@ -235,10 +235,10 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: 24
-          cache: "pnpm"
+          cache: 'pnpm'
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.x"
+          python-version: '3.x'
       - run: pnpm install --frozen-lockfile
       - uses: actions/download-artifact@v4
         with:
@@ -280,7 +280,7 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: 24
-          cache: "pnpm"
+          cache: 'pnpm'
       # npm Trusted Publisher requires npm CLI >= 11.5.1; the bundled npm may be older.
       - run: npm install -g npm@latest
       - run: pnpm install --frozen-lockfile
@@ -304,7 +304,7 @@ jobs:
     environment: nuget
     env:
       PUBLIB_DRYRUN: ${{ inputs.dry_run }}
-      NUGET_TRUSTED_PUBLISHER: "1"
+      NUGET_TRUSTED_PUBLISHER: '1'
       NUGET_USERNAME: ${{ secrets.NUGET_USERNAME }}
     steps:
       - uses: actions/checkout@v5
@@ -314,10 +314,10 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: 24
-          cache: "pnpm"
+          cache: 'pnpm'
       - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: "8.x"
+          dotnet-version: '8.x'
       - run: pnpm install --frozen-lockfile
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,14 +32,14 @@ jobs:
       sha: ${{ steps.resolve-sha.outputs.sha }}
       projects: ${{ steps.affected.outputs.projects }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           filter: tree:0
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: 'pnpm'
@@ -105,23 +105,23 @@ jobs:
     outputs:
       projects: ${{ steps.list-projects.outputs.projects }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           ref: ${{ needs.version.outputs.sha }}
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: 'pnpm'
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '17'
 
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '8.x'
 
@@ -136,7 +136,7 @@ jobs:
             pnpm nx run-many -t jsii-package-all -p "$projects"
           fi
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: jsii-dist
           path: packages/*/dist-jsii
@@ -161,20 +161,20 @@ jobs:
     env:
       PUBLIB_DRYRUN: ${{ inputs.dry_run }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           ref: ${{ needs.version.outputs.sha }}
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: 'pnpm'
 
       - run: pnpm install --frozen-lockfile
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: jsii-dist
           path: /tmp/jsii-dist
@@ -228,19 +228,19 @@ jobs:
       PUBLIB_DRYRUN: ${{ inputs.dry_run }}
       PYPI_TRUSTED_PUBLISHER: '1'
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           ref: ${{ needs.version.outputs.sha }}
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v5
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: 'pnpm'
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.x'
       - run: pnpm install --frozen-lockfile
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: jsii-dist
           path: /tmp/jsii-dist
@@ -273,18 +273,18 @@ jobs:
       NPM_TOKEN: ${{ inputs.first_release && secrets.NPM_TOKEN || '' }}
       NPM_ACCESS_LEVEL: public
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           ref: ${{ needs.version.outputs.sha }}
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v5
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: 'pnpm'
       # npm Trusted Publisher requires npm CLI >= 11.5.1; the bundled npm may be older.
       - run: npm install -g npm@latest
       - run: pnpm install --frozen-lockfile
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: jsii-dist
           path: /tmp/jsii-dist
@@ -306,19 +306,19 @@ jobs:
       NUGET_TRUSTED_PUBLISHER: '1'
       NUGET_USERNAME: ${{ secrets.NUGET_USERNAME }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           ref: ${{ needs.version.outputs.sha }}
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v5
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: 'pnpm'
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '8.x'
       - run: pnpm install --frozen-lockfile
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: jsii-dist
           path: /tmp/jsii-dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,336 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      projects:
+        description: "Comma/space-separated project names to release (e.g. core). Empty = all projects with pending changes."
+        type: string
+        default: ""
+      first_release:
+        description: "First release for the selected project(s): forces an explicit 1.0.0 (or 1.0.0-<phase>.0) version instead of a conventional-commits bump, and switches npm publish to a classic NPM_TOKEN instead of OIDC Trusted Publisher (which can't be configured on npm before the package exists)"
+        type: boolean
+        default: false
+      dry_run:
+        description: "Dry run: no git push, no real publish (PUBLIB_DRYRUN=true)"
+        type: boolean
+        default: false
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  version:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      sha: ${{ steps.resolve-sha.outputs.sha }}
+      projects: ${{ steps.affected.outputs.projects }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          filter: tree:0
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          cache: "pnpm"
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Configure release commit identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Verify branch is releasable
+        run: pnpm nx run-many -t lint test build typecheck
+
+      # `main` may only release "stable"-phase packages, `next` may only release
+      # prerelease-phase (alpha/beta/rc) packages - each package's phase lives in
+      # its project.json under `release.phase`. See tools/validate-release-phase.mjs.
+      - name: Validate release phase matches branch
+        run: >
+          node tools/validate-release-phase.mjs ${{ github.ref_name }}
+          ${{ inputs.projects && format('--projects={0}', inputs.projects) || '' }}
+
+      # Always writes real (uncommitted) files to disk, dry run or not - never
+      # passes nx's own --dry-run here - so the affected check below sees the
+      # same on-disk state either way. Nothing gets committed/tagged/pushed
+      # from this step regardless (that boundary is the next two steps).
+      #
+      # Runs one `nx release version` per project (tools/release-version.mjs)
+      # instead of a single global call, because each project's phase
+      # (alpha/beta/rc/stable) needs its own --preid.
+      - name: Bump versions
+        run: >
+          node tools/release-version.mjs
+          --git-commit=false --git-tag=false --git-push=false
+          ${{ inputs.projects && format('--projects={0}', inputs.projects) || '' }}
+          ${{ inputs.first_release && '--first-release' || '' }}
+
+      # Which projects actually need releasing, including dependents whose
+      # package.json got a dependency-range bump as a side effect of the
+      # above.
+      - name: Determine actually-affected projects
+        id: affected
+        run: echo "projects=$(pnpm --silent nx show projects --affected --json | jq -r 'join(",")')" >> "$GITHUB_OUTPUT"
+
+      - name: Generate changelogs, commit and tag per project
+        run: >
+          node tools/release-changelog.mjs --git-commit --git-tag
+          ${{ steps.affected.outputs.projects && format('--projects={0}', steps.affected.outputs.projects) || '' }}
+          ${{ inputs.first_release && '--first-release' || '' }}
+          ${{ inputs.dry_run && '--dry-run' || '' }}
+
+      - name: Push commits and tags
+        if: ${{ !inputs.dry_run }}
+        run: git push origin HEAD --follow-tags
+
+      - name: Resolve released sha
+        id: resolve-sha
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+  build-jsii:
+    needs: version
+    runs-on: ubuntu-latest
+    outputs:
+      projects: ${{ steps.list-projects.outputs.projects }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.version.outputs.sha }}
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          cache: "pnpm"
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.x"
+
+      - run: pnpm install --frozen-lockfile
+
+      # needs.version.outputs.projects is every affected project - intersect
+      # with --with-target so only the actual jsii libraries get compiled.
+      - name: Compile and package jsii artifacts for every language
+        run: |
+          projects=$(pnpm --silent nx show projects --json --with-target jsii-package-all ${{ needs.version.outputs.projects && format('-p {0}', needs.version.outputs.projects) || '' }} | jq -r 'join(",")')
+          if [ -n "$projects" ]; then
+            pnpm nx run-many -t jsii-package-all -p "$projects"
+          fi
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: jsii-dist
+          path: packages/*/dist-jsii
+          retention-days: 7
+
+      # Dynamic list of {name, root, phase} for every jsii-publishable project -
+      # lets the publish jobs below fan out per package (and pick the right npm
+      # dist-tag per package's phase) without ever hardcoding a package list here.
+      - name: List release projects
+        id: list-projects
+        run: echo "projects=$(node tools/list-release-projects.mjs '${{ needs.version.outputs.projects }}')" >> "$GITHUB_OUTPUT"
+
+  # Registries authenticated with a static secret: no per-project identity
+  # concern, so one job per language loops over every package in turn.
+  publish:
+    needs: [version, build-jsii]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        lang: [java, go]
+    env:
+      PUBLIB_DRYRUN: ${{ inputs.dry_run }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.version.outputs.sha }}
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          cache: "pnpm"
+
+      - run: pnpm install --frozen-lockfile
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: jsii-dist
+          path: /tmp/jsii-dist
+
+      - name: Restore per-package dist-jsii from artifact
+        run: |
+          for root in $(echo '${{ needs.build-jsii.outputs.projects }}' | jq -r '.[].root'); do
+            mkdir -p "$root/dist-jsii"
+            cp -r "/tmp/jsii-dist/$(basename "$root")/dist-jsii/." "$root/dist-jsii/"
+          done
+
+      - name: Publish Maven
+        if: matrix.lang == 'java'
+        env:
+          MAVEN_SERVER_ID: central-ossrh
+          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+          MAVEN_GPG_PRIVATE_KEY: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+          MAVEN_GPG_PRIVATE_KEY_PASSPHRASE: ${{ secrets.MAVEN_GPG_PRIVATE_KEY_PASSPHRASE }}
+        run: |
+          for root in $(echo '${{ needs.build-jsii.outputs.projects }}' | jq -r '.[].root'); do
+            pnpm exec publib-maven "$root/dist-jsii/java"
+          done
+
+      - name: Publish Go module mirror
+        if: matrix.lang == 'go'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_GO_MIRROR_TOKEN }}
+          GIT_USER_NAME: github-actions[bot]
+          GIT_USER_EMAIL: github-actions[bot]@users.noreply.github.com
+        run: |
+          # Every package shares the same mirror repo, each landing in its own
+          # subdirectory - the loop must stay sequential (no & backgrounding)
+          # to avoid racing pushes to the same repo.
+          for root in $(echo '${{ needs.build-jsii.outputs.projects }}' | jq -r '.[].root'); do
+            pnpm exec publib-golang "$root/dist-jsii/go"
+          done
+
+  publish-pypi:
+    needs: [version, build-jsii]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        pkg: ${{ fromJson(needs.build-jsii.outputs.projects) }}
+    environment: pypi-${{ matrix.pkg.name }}
+    env:
+      PUBLIB_DRYRUN: ${{ inputs.dry_run }}
+      PYPI_TRUSTED_PUBLISHER: "1"
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.version.outputs.sha }}
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          cache: "pnpm"
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - run: pnpm install --frozen-lockfile
+      - uses: actions/download-artifact@v4
+        with:
+          name: jsii-dist
+          path: /tmp/jsii-dist
+      - name: Restore dist-jsii from artifact
+        run: |
+          mkdir -p "${{ matrix.pkg.root }}/dist-jsii"
+          cp -r "/tmp/jsii-dist/${{ matrix.pkg.name }}/dist-jsii/." "${{ matrix.pkg.root }}/dist-jsii/"
+      - name: Publish PyPI
+        run: pnpm exec publib-pypi "${{ matrix.pkg.root }}/dist-jsii/python"
+
+  publish-npm:
+    needs: [version, build-jsii]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        pkg: ${{ fromJson(needs.build-jsii.outputs.projects) }}
+    environment: npm-${{ matrix.pkg.name }}
+    env:
+      PUBLIB_DRYRUN: ${{ inputs.dry_run }}
+      # A "stable" package publishes under npm's default "latest" tag. Anything
+      # else (alpha/beta/rc) must publish under its own phase tag so it never
+      # becomes what `npm install <pkg>` resolves to - see matrix.pkg.phase,
+      # sourced from each project's release.phase in project.json.
+      NPM_DIST_TAG: ${{ matrix.pkg.phase != 'stable' && matrix.pkg.phase || '' }}
+      NPM_TRUSTED_PUBLISHER: ${{ !inputs.first_release && '1' || '' }}
+      NPM_TOKEN: ${{ inputs.first_release && secrets.NPM_TOKEN || '' }}
+      NPM_ACCESS_LEVEL: public
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.version.outputs.sha }}
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          cache: "pnpm"
+      # npm Trusted Publisher requires npm CLI >= 11.5.1; the bundled npm may be older.
+      - run: npm install -g npm@latest
+      - run: pnpm install --frozen-lockfile
+      - uses: actions/download-artifact@v4
+        with:
+          name: jsii-dist
+          path: /tmp/jsii-dist
+      - name: Restore dist-jsii from artifact
+        run: |
+          mkdir -p "${{ matrix.pkg.root }}/dist-jsii"
+          cp -r "/tmp/jsii-dist/${{ matrix.pkg.name }}/dist-jsii/." "${{ matrix.pkg.root }}/dist-jsii/"
+      - name: Publish npm
+        run: pnpm exec publib-npm "${{ matrix.pkg.root }}/dist-jsii/js"
+
+  publish-nuget:
+    needs: [version, build-jsii]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    environment: nuget
+    env:
+      PUBLIB_DRYRUN: ${{ inputs.dry_run }}
+      NUGET_TRUSTED_PUBLISHER: "1"
+      NUGET_USERNAME: ${{ secrets.NUGET_USERNAME }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.version.outputs.sha }}
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          cache: "pnpm"
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.x"
+      - run: pnpm install --frozen-lockfile
+      - uses: actions/download-artifact@v4
+        with:
+          name: jsii-dist
+          path: /tmp/jsii-dist
+      - name: Restore per-package dist-jsii from artifact
+        run: |
+          for root in $(echo '${{ needs.build-jsii.outputs.projects }}' | jq -r '.[].root'); do
+            mkdir -p "$root/dist-jsii"
+            cp -r "/tmp/jsii-dist/$(basename "$root")/dist-jsii/." "$root/dist-jsii/"
+          done
+      - name: Publish NuGet
+        run: |
+          for root in $(echo '${{ needs.build-jsii.outputs.projects }}' | jq -r '.[].root'); do
+            pnpm exec publib-nuget "$root/dist-jsii/dotnet"
+          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -301,7 +301,6 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    environment: nuget
     env:
       PUBLIB_DRYRUN: ${{ inputs.dry_run }}
       NUGET_TRUSTED_PUBLISHER: '1'

--- a/nx.json
+++ b/nx.json
@@ -57,8 +57,15 @@
     }
   },
   "release": {
+    "projectsRelationship": "independent",
     "version": {
-      "preVersionCommand": "pnpm dlx nx run-many -t build"
+      "preVersionCommand": "pnpm dlx nx run-many -t build --exclude=tag:e2e",
+      "conventionalCommits": true,
+      "preserveMatchingDependencyRanges": false
+    },
+    "changelog": {
+      "workspaceChangelog": false,
+      "projectChangelogs": { "createRelease": false }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,17 +24,19 @@
     "jest-environment-node": "~30.3.0",
     "jest-util": "~30.3.0",
     "jsii": "^6.0.7",
+    "jsii-docgen": "^10.12.4",
     "jsii-pacmak": "^1.139.0",
     "jsii-rosetta": "^6.0.7",
     "jsonc-eslint-parser": "^2.1.0",
     "nx": "23.1.0",
     "prettier": "^3.8.1",
+    "publib": "^0.2.1055",
     "ts-jest": "^29.4.7",
     "ts-node": "10.9.1",
     "tslib": "^2.3.0",
     "typescript": "~6.0.3",
     "typescript-eslint": "^8.58.0",
-    "verdaccio": "^6.3.2"
+    "verdaccio": "6.7.4"
   },
   "nx": {
     "includedScripts": [],

--- a/packages/core/jest.config.cts
+++ b/packages/core/jest.config.cts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 const { readFileSync } = require('fs');
 
 // Reading the SWC compilation config for the spec files

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@cdk-x/core",
-  "version": "0.0.1",
+  "version": "1.0.0-alpha.0",
+  "stability": "experimental",
   "type": "module",
   "description": "Core constructs (App, Stack, Resource, Component) for the cdkx framework.",
   "main": "./dist/index.js",

--- a/packages/core/project.json
+++ b/packages/core/project.json
@@ -4,6 +4,7 @@
   "sourceRoot": "packages/core/src",
   "projectType": "library",
   "tags": [],
+  "release": { "phase": "alpha" },
   "targets": {
     "build": {
       "executor": "@nx/js:swc",
@@ -23,6 +24,15 @@
       "options": {
         "cwd": "packages/core",
         "command": "jsii --generate-tsconfig tsconfig.jsii.json"
+      }
+    },
+    "jsii-docs": {
+      "executor": "nx:run-commands",
+      "dependsOn": ["jsii-compile"],
+      "outputs": ["{projectRoot}/dist-jsii/docs"],
+      "options": {
+        "cwd": "packages/core",
+        "command": "jsii-docgen -l typescript -l python -l java -l csharp -l go -o dist-jsii/docs/API"
       }
     },
     "jsii-package-npm": {
@@ -73,12 +83,53 @@
     "jsii-package-all": {
       "executor": "nx:noop",
       "dependsOn": [
+        "jsii-docs",
         "jsii-package-npm",
         "jsii-package-python",
         "jsii-package-java",
         "jsii-package-dotnet",
         "jsii-package-go"
       ]
+    },
+    "jsii-publish-npm": {
+      "executor": "nx:run-commands",
+      "dependsOn": ["jsii-package-npm"],
+      "options": {
+        "cwd": "packages/core",
+        "command": "publib-npm dist-jsii/js"
+      }
+    },
+    "jsii-publish-python": {
+      "executor": "nx:run-commands",
+      "dependsOn": ["jsii-package-python"],
+      "options": {
+        "cwd": "packages/core",
+        "command": "publib-pypi dist-jsii/python"
+      }
+    },
+    "jsii-publish-java": {
+      "executor": "nx:run-commands",
+      "dependsOn": ["jsii-package-java"],
+      "options": {
+        "cwd": "packages/core",
+        "command": "publib-maven dist-jsii/java"
+      }
+    },
+    "jsii-publish-dotnet": {
+      "executor": "nx:run-commands",
+      "dependsOn": ["jsii-package-dotnet"],
+      "options": {
+        "cwd": "packages/core",
+        "command": "publib-nuget dist-jsii/dotnet"
+      }
+    },
+    "jsii-publish-go": {
+      "executor": "nx:run-commands",
+      "dependsOn": ["jsii-package-go"],
+      "options": {
+        "cwd": "packages/core",
+        "command": "publib-golang dist-jsii/go"
+      }
     }
   }
 }

--- a/packages/core/src/lib/component/component.spec.ts
+++ b/packages/core/src/lib/component/component.spec.ts
@@ -9,7 +9,7 @@ class DummyComponent extends Component {}
 class DummyResource extends Resource {
   public readonly type = 'Dummy::Resource';
 
-  protected toProperties(): Record<string, any> {
+  protected toProperties(): Record<string, unknown> {
     return {};
   }
 }

--- a/packages/core/src/lib/resolvable/resolvable.spec.ts
+++ b/packages/core/src/lib/resolvable/resolvable.spec.ts
@@ -47,7 +47,7 @@ describe('Resolvable', () => {
     it('accepts an IResolvable nested anywhere within an arbitrary properties tree', () => {
       const resolvable: IResolvable = { resolve: () => 'resolved' };
 
-      const value: any = {
+      const value: Record<string, unknown> = {
         name: 'example',
         count: 1,
         enabled: true,

--- a/packages/core/src/lib/resource/resource.spec.ts
+++ b/packages/core/src/lib/resource/resource.spec.ts
@@ -7,7 +7,7 @@ import { Resource } from './resource.js';
 class DummyResource extends Resource {
   public readonly type = 'Dummy::Resource';
 
-  protected toProperties(): Record<string, any> {
+  protected toProperties(): Record<string, unknown> {
     return {};
   }
 }

--- a/packages/core/src/lib/resource/resource.ts
+++ b/packages/core/src/lib/resource/resource.ts
@@ -131,13 +131,16 @@ export abstract class Resource extends Construct {
    * sense for their output format (e.g. Steps under "steps") — core has
    * no opinion on this.
    *
-   * Typed as `Record<string, any>` rather than a stricter JSON-tree union:
-   * jsii cannot represent a recursive union type across its target
-   * languages (Java/.NET/Go), so `any` is the jsii-compatible convention
-   * here, mirroring how aws-cdk-lib types arbitrary resource property
-   * trees.
+   * Typed as `Record<string, unknown>` rather than a stricter JSON-tree union:
+   * jsii cannot represent a recursive union type across its target languages
+   * (Java/.NET/Go) — `unknown` is what jsii falls back to for an untyped
+   * value (it compiles to the same `any`-equivalent per language as `any`
+   * would), but keeps callers within this TS codebase honest, since they
+   * still have to narrow before reading through it (see
+   * Synthesizer.synthesizeStack's cast to the internal PropertyValue tree
+   * for where that trust boundary is).
    */
-  protected abstract toProperties(): Record<string, any>;
+  protected abstract toProperties(): Record<string, unknown>;
 
   /**
    * Internal hook used by Synthesizer to read this Resource's raw
@@ -147,7 +150,7 @@ export abstract class Resource extends Construct {
    *
    * @internal
    */
-  public _toProperties(): Record<string, any> {
+  public _toProperties(): Record<string, unknown> {
     return this.toProperties();
   }
 }

--- a/packages/core/src/lib/stack/stack.spec.ts
+++ b/packages/core/src/lib/stack/stack.spec.ts
@@ -6,7 +6,7 @@ import { Stack } from './stack.js';
 class DummyResource extends Resource {
   public readonly type = 'Dummy::Resource';
 
-  protected toProperties(): Record<string, any> {
+  protected toProperties(): Record<string, unknown> {
     return {};
   }
 }

--- a/packages/core/src/lib/synth/synth.spec.ts
+++ b/packages/core/src/lib/synth/synth.spec.ts
@@ -6,9 +6,9 @@ import { CycleError, Synthesizer } from './synth.js';
 
 class DummyResource extends Resource {
   public readonly type = 'Dummy::Resource';
-  public properties: Record<string, any> = {};
+  public properties: Record<string, unknown> = {};
 
-  protected toProperties(): Record<string, any> {
+  protected toProperties(): Record<string, unknown> {
     return this.properties;
   }
 }

--- a/packages/core/src/lib/synth/synth.ts
+++ b/packages/core/src/lib/synth/synth.ts
@@ -27,7 +27,7 @@ export interface ManifestEntry {
    * This Resource's serialized properties — any IResolvable values have
    * been replaced with their resolved (placeholder) form.
    */
-  readonly properties: Record<string, any>;
+  readonly properties: Record<string, unknown>;
 
   /**
    * The logical ids (Resource.node.path) of every Resource this entry
@@ -124,7 +124,15 @@ export class Synthesizer {
     const manifest: Manifest = {};
 
     for (const resource of stack.resources()) {
-      const rawProps = resource._toProperties();
+      // Trust boundary: toProperties() is typed Record<string, unknown> on
+      // the public (jsii-facing) side since a recursive union like
+      // PropertyValue can't cross jsii's language targets. Internally we
+      // still need that shape to walk/serialize it, so it's asserted once,
+      // here, rather than widened back to `any` throughout this file.
+      const rawProps = resource._toProperties() as Record<
+        string,
+        PropertyValue
+      >;
       manifest[resource.node.path] = {
         type: resource.type,
         properties: Synthesizer.serializeResolvables(rawProps),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,16 +13,16 @@ importers:
         version: 9.39.5
       '@nx/eslint':
         specifier: 23.1.0
-        version: 23.1.0(@babel/traverse@7.29.7)(@nx/jest@23.1.0(ddb785a3f7d67d276dfea5db0c3ebae1))(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@6.0.3))(@swc/cli@0.8.1(@swc/core@1.15.8(@swc/helpers@0.5.18)))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(eslint@9.39.5)(nx@23.1.0(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@6.0.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.9.0(typanion@3.14.0))
+        version: 23.1.0(@babel/traverse@7.29.7)(@nx/jest@23.1.0(5c506a22c4dc7197bda76a9c56e40cf7))(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@6.0.3))(@swc/cli@0.8.1(@swc/core@1.15.8(@swc/helpers@0.5.18)))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(eslint@9.39.5)(nx@23.1.0(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@6.0.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.7.4(typanion@3.14.0))
       '@nx/eslint-plugin':
         specifier: 23.1.0
-        version: 23.1.0(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@6.0.3))(@swc/cli@0.8.1(@swc/core@1.15.8(@swc/helpers@0.5.18)))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@typescript-eslint/parser@8.65.0(eslint@9.39.5)(typescript@6.0.3))(eslint-config-prettier@10.1.8(eslint@9.39.5))(eslint@9.39.5)(nx@23.1.0(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@6.0.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(typescript@6.0.3)(verdaccio@6.9.0(typanion@3.14.0))
+        version: 23.1.0(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@6.0.3))(@swc/cli@0.8.1(@swc/core@1.15.8(@swc/helpers@0.5.18)))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@typescript-eslint/parser@8.65.0(eslint@9.39.5)(typescript@6.0.3))(eslint-config-prettier@10.1.8(eslint@9.39.5))(eslint@9.39.5)(nx@23.1.0(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@6.0.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(typescript@6.0.3)(verdaccio@6.7.4(typanion@3.14.0))
       '@nx/jest':
         specifier: 23.1.0
-        version: 23.1.0(ddb785a3f7d67d276dfea5db0c3ebae1)
+        version: 23.1.0(5c506a22c4dc7197bda76a9c56e40cf7)
       '@nx/js':
         specifier: 23.1.0
-        version: 23.1.0(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@6.0.3))(@swc/cli@0.8.1(@swc/core@1.15.8(@swc/helpers@0.5.18)))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@23.1.0(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@6.0.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.9.0(typanion@3.14.0))
+        version: 23.1.0(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@6.0.3))(@swc/cli@0.8.1(@swc/core@1.15.8(@swc/helpers@0.5.18)))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@23.1.0(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@6.0.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.7.4(typanion@3.14.0))
       '@swc-node/register':
         specifier: 1.11.1
         version: 1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@6.0.3)
@@ -62,6 +62,9 @@ importers:
       jsii:
         specifier: ^6.0.7
         version: 6.0.7
+      jsii-docgen:
+        specifier: ^10.12.4
+        version: 10.12.5(jsii-rosetta@6.0.7)
       jsii-pacmak:
         specifier: ^1.139.0
         version: 1.139.0(jsii-rosetta@6.0.7)
@@ -77,6 +80,9 @@ importers:
       prettier:
         specifier: ^3.8.1
         version: 3.9.6
+      publib:
+        specifier: ^0.2.1055
+        version: 0.2.1057
       ts-jest:
         specifier: ^29.4.7
         version: 29.4.12(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.7))(jest-util@30.3.0)(jest@30.3.0(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@24.13.3)(typescript@6.0.3)))(typescript@6.0.3)
@@ -93,8 +99,8 @@ importers:
         specifier: ^8.58.0
         version: 8.65.0(eslint@9.39.5)(typescript@6.0.3)
       verdaccio:
-        specifier: ^6.3.2
-        version: 6.9.0(typanion@3.14.0)
+        specifier: 6.7.4
+        version: 6.7.4(typanion@3.14.0)
 
   packages/core:
     dependencies:
@@ -106,6 +112,78 @@ importers:
         version: 10.8.0
 
 packages:
+
+  '@aws-sdk/client-codeartifact@3.1101.0':
+    resolution: {integrity: sha512-wn4lU98sYxNIjqKqgEIaHQpPODX69P3EvjCLx8z59+ttjYi9gxfiLeprgweNzdvXsIchesCJaHIXPbE+X4NGig==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.977.4':
+    resolution: {integrity: sha512-CEkcQlMOQJCvul60U7wdAOACjtdgFWDsfJI+6wUOGdhGNV2lGbuJpi/R50QLpFG3Tp+sQxa/RmzC3X7KHbhuTA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-cognito-identity@3.972.64':
+    resolution: {integrity: sha512-bilBheDT6GKnFkPnovgt1HL5spmnTCntm8w+hO3bmjnlZ8qMhqfQ1RJYPRTNsPlXaCcBXWUtg+zn/NM6WQUXoA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.65':
+    resolution: {integrity: sha512-lJT2aRw9wCV8jPHyFJjdZLD4HTydL6/22AnCSOB8e/LqOc55nEJGLHkJQeSxhn8QiqyjFwPKQFtMw0ovjRUY/g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.67':
+    resolution: {integrity: sha512-N7fw/15hSwI/CPxe5ohOyb7O4ge9f5me1gVIn8OIkBRB0squ8OJqQyDyH/HoL+Sb1W5xdC88jVC+bHkw73iu+Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.973.10':
+    resolution: {integrity: sha512-Zh9XRaPnDN9buO7GfWBubS22R6Nq5D6hbyYEMN05LiOnXugm/8WDjUx6y756bSPbdn3aJB2qG4zFW3bN82QhoQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.72':
+    resolution: {integrity: sha512-zZapIKwaHp7TdTf9hbH1I3CVUdEupmt7FXO/BoTQGC+4h6NkXKWpqF2p5WyfpjurDLHCpSyh+BzMlAg8arqWLA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.76':
+    resolution: {integrity: sha512-1yzLmRiYSgGC25v7ZZEwJn/auhHHTIHgFOmzL2f36hf1+7jSLcX+1QrAz4760WEzPiiQl8xmlpFhHfl2OoyVzA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.65':
+    resolution: {integrity: sha512-e5DbbNteOSalN58U83G6kFa4ECLEuGbGqNBHIXE7zYXA/m4GHblIGjFbSH7wYv6gBV8iNSDcRZBKfQZF5vF9nw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.973.9':
+    resolution: {integrity: sha512-0V0u4t+KBku9fbh5CPCaC5hUWwSzDafp8nCuDy817zWbp2gz80jO44rMQkiwnZ+k54B+tjAtzRy00DJRGTKGBg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.71':
+    resolution: {integrity: sha512-e4dwiRltGAaQ+2yxw57Hj0l/BF3BHiG14+QpYE7bGYBlpAq/fkIri2BDhjWon8c0mhhtd2txQBAkQb9BcTStFg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-providers@3.1101.0':
+    resolution: {integrity: sha512-w19SnW8MMP/tFghHRA6zmKQJar/BVdrFq4leh4doCCMWWIwEsP8F3mP1VnpPXCwmrtUjVoQVxm/4wV/SwhkTrw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.39':
+    resolution: {integrity: sha512-wU5NPnj62Sb7A8xn/Zb+xThe05P3otNtDl37iOIi5DDMeCesNeCckaG+eXWGUs12Z9R34I8CD05TaTe6SIa61g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.43':
+    resolution: {integrity: sha512-lKekx8bLBXSv4O+cslk9Zfnw2XKSkWBs3uWL5QGhH2ZAQfNS7FE0vcSSN2vD/AhxX54ZTywWxR4STThoeOXlBA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1100.0':
+    resolution: {integrity: sha512-THf3MkgY3fNJZ3zdgSenLqR7gSE68KccCj1RCKretlG73Ppszvues02VpCUO9NlB/tZDC483FvGCld+AiPCkvg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.974.2':
+    resolution: {integrity: sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.37':
+    resolution: {integrity: sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.3.0':
+    resolution: {integrity: sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==}
+    engines: {node: '>=18.0.0'}
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -733,9 +811,9 @@ packages:
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
 
-  '@cypress/request@4.0.1':
-    resolution: {integrity: sha512-y20e+e6dFYkOUUJLVUZTsJRuTiXZaUQ32WD+R/ux/HBybbTx4ge7cNINcua0pU8+SNkKuRbOF12mBmzuzM8n5w==}
-    engines: {node: '>= 14.17.0'}
+  '@cypress/request@3.0.10':
+    resolution: {integrity: sha512-hauBrOdvu08vOsagkZ/Aju5XuiZx6ldsLfByg1htFeldhex+PeMrYauANzFsMJeAA0+dyPLbDoX2OYuvVoLDkQ==}
+    engines: {node: '>= 6'}
 
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
@@ -1386,13 +1464,13 @@ packages:
   '@sinclair/typebox@0.34.52':
     resolution: {integrity: sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw==}
 
+  '@sindresorhus/is@4.6.0':
+    resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
+    engines: {node: '>=10'}
+
   '@sindresorhus/is@7.2.0':
     resolution: {integrity: sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==}
     engines: {node: '>=18'}
-
-  '@sindresorhus/is@8.1.0':
-    resolution: {integrity: sha512-2SX/1jW6CIMAiebvVv5ZInoCEuWQmMyBoJXXGC6Vjakjp/fpxP5eHs7/V6WKuPEIbuK06+VpjH+vjLQhr98rDQ==}
-    engines: {node: '>=22'}
 
   '@sindresorhus/merge-streams@4.0.0':
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
@@ -1403,6 +1481,30 @@ packages:
 
   '@sinonjs/fake-timers@15.4.0':
     resolution: {integrity: sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==}
+
+  '@smithy/core@3.31.1':
+    resolution: {integrity: sha512-CyogUINxvi7C7LDsh8Syo6hVJOT9ckz4rG8dRZfTJ8r91HkMY59PnNooaj7WcHyxEkxPfBAmbgztZU+xTo76lg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.4.16':
+    resolution: {integrity: sha512-QfuLWAkLzptffFW980AFeHZFdqds2B64rpEd3uJ6lgs3xVn9QegGMUgUcj+4d7dRrAsya3r58ZKpku97WcFb4w==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.6.13':
+    resolution: {integrity: sha512-4fW86pEUOMbrD5nkbyl/tTvPHHWJFbuB2odl6ps9lWfHoXf9HWh3Q/Smh59qH1g7+c/BSZghX6bbUk4gsiMs8A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-http-handler@4.9.13':
+    resolution: {integrity: sha512-Nmd/Nl35zfYrd+a6OO2cDJb3GPh9bgTjIUhcM+JFfjpp8/osCgboDV5nCT1I01Pv6R13eSKDKLSoVa5ZB6Zsfw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.6.12':
+    resolution: {integrity: sha512-I6KLtq3H0qqSuV9vLglfi8puHqzygzWHOnI4z/Rdoo+q50vvo18vBRdPAvvEtcaKROz7Zn6qnPa14kRfPH6PcQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.16.1':
+    resolution: {integrity: sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==}
+    engines: {node: '>=18.0.0'}
 
   '@swc-node/core@1.15.0':
     resolution: {integrity: sha512-WAerrrl087WgenB92XG4Th2t0NQFfMNLYSe0sW2cEMMqM/LQmP4rozsDJl0vuzTrbewjpKQryxFXI+aYig/dBg==}
@@ -1519,6 +1621,10 @@ packages:
   '@swc/types@0.1.27':
     resolution: {integrity: sha512-K6h3iUlqeM946U4sXFYeahefR1YBbXJvko+hv8WS8/0BNJ4OHiHRywMnQUJCqkR7Y9+hqQ1TvEpiKqUhz7NEFg==}
 
+  '@szmarczak/http-timer@4.0.6':
+    resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
+    engines: {node: '>=10'}
+
   '@tokenizer/inflate@0.4.1':
     resolution: {integrity: sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==}
     engines: {node: '>=18'}
@@ -1562,6 +1668,9 @@ packages:
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
+  '@types/fs-extra@8.1.5':
+    resolution: {integrity: sha512-0dzKcwO+S8s2kuF5Z9oUWatQJj5Uq/iqphEtE3GQJVRRYm/tD1LglU2UnXi2A8jLq5umkGouOXOR9y0n613ZwQ==}
+
   '@types/http-cache-semantics@4.2.0':
     resolution: {integrity: sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==}
 
@@ -1585,6 +1694,9 @@ packages:
 
   '@types/parse-json@4.0.2':
     resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
+
+  '@types/responselike@1.0.0':
+    resolution: {integrity: sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==}
 
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
@@ -1777,80 +1889,80 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@verdaccio/auth@8.1.0':
-    resolution: {integrity: sha512-ArnRMIQeyr1AN7t4Hk9EaiWOb1qAuESXgkoySX5nCIv2BKlF6JHLff2HcmxMrrzsBb8C6QwtD9yU+zZUK5xehw==}
-    engines: {node: '>=22'}
+  '@verdaccio/auth@8.0.4':
+    resolution: {integrity: sha512-hB7LU0Et6l3zkVmGV2SBEcMLCixUR26otiJVb7CpxnU1/j8BxWNVX9/HnwG16vLwXsSICUq4Ez+qROE/GdxLgQ==}
+    engines: {node: '>=18'}
 
-  '@verdaccio/config@8.2.0':
-    resolution: {integrity: sha512-GuC0c3abP75+su2CyVTmMMFqsTqr9V7gB4c47o3OIozrNXIoJDi4BcSVggSZ1nYHZHaIyos6vQjH8b8NaR0CJg==}
-    engines: {node: '>=22'}
+  '@verdaccio/config@8.1.2':
+    resolution: {integrity: sha512-GX8TcEHcFaMxdGVRlkFZGJJvEgsQS2jkA5WjV4xKhK3B7z5UOhr75zEqoqATfVPuBPBT6kM/QkvyAGq4W5GTaA==}
+    engines: {node: '>=18'}
 
-  '@verdaccio/core@8.2.0':
-    resolution: {integrity: sha512-tK1QgY3Kl8n71Q5lvPsMEe2Kv6Rk1Vd6SUUCP7om8ARuDvLkvRgJ1o8Tq7vqYWkPRIPiowdPt18uEjcJo1moAw==}
-    engines: {node: '>=22'}
+  '@verdaccio/core@8.1.2':
+    resolution: {integrity: sha512-VtpBz9R61GTFUxPiQmBhCOffQZRJZMA2EXO/FzbaoNczm/Xt2KkDJq0PPwV5qmRGeouDRxEKUQ+caJGVN0W7Ww==}
+    engines: {node: '>=18'}
 
-  '@verdaccio/file-locking@13.1.0':
-    resolution: {integrity: sha512-rGFfdyCZdgpbkROJJfjOA01R5BFtzrnDAhNIkxxc/yWZ6Cir+MRHpEbN2weOEPAwYDke9Wms4JKhpsStu+iV8Q==}
-    engines: {node: '>=22'}
+  '@verdaccio/file-locking@13.0.1':
+    resolution: {integrity: sha512-SZ9uxnQKppiM+/67xTaaBP4AZ/Q+weUB22ci1gF861icYWhWFu3njA3ofYig/4yNqkYRVEKVAIwnH97BaBEYbg==}
+    engines: {node: '>=18'}
 
-  '@verdaccio/hooks@8.1.1':
-    resolution: {integrity: sha512-CiGb5n1SKmtxnE128PFjeaEWksLr9Fh+W8/hONKR4W7H6FHHmLbjPkiKzQus8uNa+2cnIRozv+M06zV54Jt1Hw==}
-    engines: {node: '>=22'}
+  '@verdaccio/hooks@8.0.3':
+    resolution: {integrity: sha512-5e71ArLhvcc/CFkDZW/gS3GWFkIAgIr0SCmEUXsTYHoqfyLV6VlXIpb6baGCnQ1EoQQ5ZkHtaWNFxSzM96ZlXA==}
+    engines: {node: '>=18'}
 
-  '@verdaccio/loaders@8.1.0':
-    resolution: {integrity: sha512-9NyKDnqVOQi5YI7/rlBoL65EKr8OH45D/kiAaShgW1tE1rLzalM082P0+waZW1x2fCEjeIE8EM0KkoH668hxrA==}
-    engines: {node: '>=22'}
+  '@verdaccio/loaders@8.0.3':
+    resolution: {integrity: sha512-QG7zmQ9YuJgkC63zAMXP0IWafT9wvv/VWx97l0aaWLdXfJqK/l7+B7FgaEK0uZxq92Z+fU6tGaw5h2oe6XIFTg==}
+    engines: {node: '>=18'}
 
-  '@verdaccio/local-storage-legacy@11.4.0':
-    resolution: {integrity: sha512-pNeszXr4aEjahL2lKtnDpMNjZ2O44WV9tbw+vii5QCamAt44H77O1yLF2e+mWEJdW6ufIPNy6hB9Ct1hKk2f7Q==}
-    engines: {node: '>=22'}
+  '@verdaccio/local-storage-legacy@11.3.4':
+    resolution: {integrity: sha512-YdHF9hsn4OhZf1v0rQITtQt5qYn2zw8crHEhW54P0/OgxB5HPxxs93woUh/f0yqftIdB545o5Q38d7AuVgBWvg==}
+    engines: {node: '>=18'}
 
-  '@verdaccio/logger-commons@8.1.0':
-    resolution: {integrity: sha512-7mAhzo7uFvB0pNX48eQRHnJ/qSXPzADT6eYoz71Nsz6u+ofXXjblvOVngGc6jQ/hs0ezusa1I9dU+LSJV2ciVg==}
-    engines: {node: '>=22'}
+  '@verdaccio/logger-commons@8.0.3':
+    resolution: {integrity: sha512-EpNnGYtzZd5ZPKOBTllu6cYn6oX2U67RGzI/390T2MRSsX+HBYVSw8JSaqzsgpg7khXL1U2iQvNI5SVfItLJ0w==}
+    engines: {node: '>=18'}
 
-  '@verdaccio/logger-prettify@8.1.0':
-    resolution: {integrity: sha512-Mriivx1LPx8/8ux0MlNoj/FtxQiQmf5BG2casfWEf9R7jzBDAUCqQJUR4s0PaV2Mlc9cdHcETOucx3RGPuWHeQ==}
-    engines: {node: '>=22'}
+  '@verdaccio/logger-prettify@8.0.1':
+    resolution: {integrity: sha512-49a5LTi90TxjQPBk7rZUf0qCorAjOopq7uQzGRro6dOEFmyaZ/K2sNiOuRFJzVuC8C8jL/zPlJiln1vm5HsAMA==}
+    engines: {node: '>=18'}
 
-  '@verdaccio/logger@8.1.0':
-    resolution: {integrity: sha512-4DpZQTstCpgr5A5lc3X9P+ZlPx/LObvKG4hJWxSjDWsg20clgKPkL22fMfNItNf/ZpHCVpLM0PriFLoMlMTGHA==}
-    engines: {node: '>=22'}
+  '@verdaccio/logger@8.0.3':
+    resolution: {integrity: sha512-fngfyx6gUX416UYL0nqJy2yy0AxKFsfXppy6L4Dggvxu3A/auQucBtiHUj8J02jc4C1HAPTdvwIpt79Uxjr3qg==}
+    engines: {node: '>=18'}
 
-  '@verdaccio/middleware@8.1.0':
-    resolution: {integrity: sha512-+3Tx5IzbOtR1DYWn6n36jx7d6Qi9tXfcYMm0RvCMJHVCRlJ6UR2/B2CnaDBj0fiJJLclUdwYJOZQpZLr/YKMVQ==}
-    engines: {node: '>=22'}
+  '@verdaccio/middleware@8.0.5':
+    resolution: {integrity: sha512-jhs7oE4KKuVRrudyk3mOF0yfWelBSi8s7moAHO+bJQwpXNpMNsGFuVRpF/8zBbqSEJshMukxcQYIeKusnsL24A==}
+    engines: {node: '>=18'}
 
-  '@verdaccio/package-filter@13.1.0':
-    resolution: {integrity: sha512-iHAm31ipcu90DItkQkzMRr7ygktDZ+qmFFn0Dt8r8HWE9BQk3zRRll6KbrJI0L81ZWFMIauzG/2KYW94Kvpkmw==}
-    engines: {node: '>=22'}
+  '@verdaccio/package-filter@13.0.3':
+    resolution: {integrity: sha512-kfchn7GTxjfpcZqe1kwy9ZfYc2oCYVdzWHz2Nw5RLqpA+tIar5kS2GqlGpOLU7qYfPqDLQcHiv69PtxRstGtew==}
+    engines: {node: '>=18'}
 
-  '@verdaccio/search-indexer@8.1.0':
-    resolution: {integrity: sha512-N0vHWnSCZVEU3ffvbH/g4cRvGkXO+FJQcNggdY1wxT8LP7K6NJ0F6aq7jSF3ebW5IokdQMJuqWTNx18h8dgrsg==}
-    engines: {node: '>=22'}
+  '@verdaccio/search-indexer@8.0.2':
+    resolution: {integrity: sha512-Pd2vGmb69pMuZj+WyiUMcbPU9H9Zfm0xHy0p2jDhb4PfT0rnoGgM0a7GxlmywsRuIM5obm4OCUZdhw0N8BnwYw==}
+    engines: {node: '>=18'}
 
-  '@verdaccio/signature@8.1.0':
-    resolution: {integrity: sha512-8ix5OT8TXWzZuCYWWIVGDB6G0wsSkT/VDbeQWXZr57P4LRGpFSe4OtdR2A0YFPFCE3YgOz+LiHdabUmpOC6f2A==}
-    engines: {node: '>=22'}
+  '@verdaccio/signature@8.0.3':
+    resolution: {integrity: sha512-EBaBMI3aHHdGk+1gABPye/lo5ey7ilRJJtFFaqI7nIup4xC5U6N2Z1ULtKqk/ubzB1O82vDuE2ZFnK8qe6rImg==}
+    engines: {node: '>=18'}
 
-  '@verdaccio/streams@10.3.0':
-    resolution: {integrity: sha512-MARQAzAgS42GIawkrBVMTV81vRf2yqZmwonnQb9FWeGj+tsMcgpT/f2fWMQm/UubLpWxBBH6oCkmhFd29R2xGA==}
-    engines: {node: '>=22', npm: '>=5'}
+  '@verdaccio/streams@10.2.5':
+    resolution: {integrity: sha512-nVnTYeMJ7h131Nkv2svqZCfL5aDkJbwUvQd4OGXssbJJR5BfB2PzNq8TD45lEXIBW3EMMMFs7mVY789ds9soIA==}
+    engines: {node: '>=12', npm: '>=5'}
 
-  '@verdaccio/tarball@13.1.0':
-    resolution: {integrity: sha512-y1hLbJkv0Keo338oqtBOlAdDWRl5+K9GaSjiINaD9U4fiRqppR6Ktj1UPAj6tGL1OGtNUAPM3xobgzWKc7/2QQ==}
-    engines: {node: '>=22'}
+  '@verdaccio/tarball@13.0.3':
+    resolution: {integrity: sha512-BKdksIRaqhrptP6JmVW71TeUTuA1hHWcGeEabSDzYgi1PXgLS9l8On3HWLs+TZ93PRtTjZiZJGCJPbqoy5itvg==}
+    engines: {node: '>=18'}
 
-  '@verdaccio/ui-theme@9.0.0-next-9.21':
-    resolution: {integrity: sha512-w423IDgBOTmUW94CF84bXosW9Kg6khNhbGxCAPEOtE7yZUyASMxoZP14Ro3N2F492pd0Nd/MV3a//opI+SNPQA==}
+  '@verdaccio/ui-theme@9.0.0-next-9.20':
+    resolution: {integrity: sha512-eo4xqFzzUU382zKozJxipJGLp3HUNQvMZ81oTBa0SZ+Q/Bk2Fum82qAiE5ww4hTaVDV0Rjb7fqC4qJeBuLcGww==}
 
-  '@verdaccio/url@13.1.0':
-    resolution: {integrity: sha512-ghkA4mqImQLTefbL0LbEtDz8KVL+jhFGfAPfbVx/voPRbzZA++5Wo+10y3kVVI4JfWa510LWYT0qvk5Q6RgBEA==}
-    engines: {node: '>=22'}
+  '@verdaccio/url@13.0.3':
+    resolution: {integrity: sha512-BGH19Qc0pwoefyafJ100izQkgqKuuSF0EVdNjgipG8154yIluELxyliL8cqvTTDVZLVwz/CBuBq8IpUU9lhv9g==}
+    engines: {node: '>=18'}
 
-  '@verdaccio/utils@8.2.0':
-    resolution: {integrity: sha512-S4qjAkmr3mtDx7KJj5eKS1y7UiQDQ6+NUZ5yARJC7ErXbE8sZBoR1Z6lQKeeBBTmaT56DtZvjeIkvbzQEW/87w==}
-    engines: {node: '>=22'}
+  '@verdaccio/utils@8.1.3':
+    resolution: {integrity: sha512-tJ3XO0MaFe8gx9oiLBu3Jim8JVyJRC08c2Y4dfx3wd1j9HlVkiWnW5qYOoTHA4NfdMzugsBsI8GlX3v/y/EtPg==}
+    engines: {node: '>=18'}
 
   '@xhmikosr/archive-type@8.1.0':
     resolution: {integrity: sha512-EXOjEbnZFE5c/nFMf4FOrEURVanzHpnkPYmnmr78u02/8hAhE0FMq8p9TK1IM0/bFr5VcyBUY0gfLm8f7dKy+Q==}
@@ -2152,6 +2264,9 @@ packages:
     resolution: {integrity: sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
+
   brace-expansion@1.1.16:
     resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
 
@@ -2201,6 +2316,10 @@ packages:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
 
+  cacheable-lookup@6.1.0:
+    resolution: {integrity: sha512-KJ/Dmo1lDDhmW2XDPMo+9oiy/CeqosPguPCrgcVzKyZrL6pM1gU2GmPY/xo6OQPTUaA/c0kwHuywB4E6nmT9ww==}
+    engines: {node: '>=10.6.0'}
+
   cacheable-lookup@7.0.0:
     resolution: {integrity: sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==}
     engines: {node: '>=14.16'}
@@ -2208,6 +2327,10 @@ packages:
   cacheable-request@13.0.19:
     resolution: {integrity: sha512-SVXGH037+Mo1aIMO5B2UcleR43FGjFdN+M8JObSyEoQ2Mn4CODRWx28gN5jiTF0n5ItsgtIZfyargMNs8GX4kg==}
     engines: {node: '>=18'}
+
+  cacheable-request@7.0.2:
+    resolution: {integrity: sha512-pouW8/FmiPQbuGpkXQ9BAPv/Mo5xDGANgSNXzTzJ8DrKGuXOssM4wIQRjfanNRh3Yu5cfYPvcorqbhg2KIJtew==}
+    engines: {node: '>=8'}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -2247,10 +2370,6 @@ packages:
     resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
     engines: {node: '>=10'}
 
-  chunk-data@0.1.0:
-    resolution: {integrity: sha512-zFyPtyC0SZ6Zu79b9sOYtXZcgrsXe0RpePrzRyj52hYVFG1+Rk6rBqjjOEk+GNQwc3PIX+86teQMok970pod1g==}
-    engines: {node: '>=20'}
-
   ci-info@4.4.0:
     resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
     engines: {node: '>=8'}
@@ -2271,9 +2390,15 @@ packages:
     peerDependencies:
       typanion: '*'
 
+  cliui@7.0.4:
+    resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
+
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
+
+  clone-response@1.0.3:
+    resolution: {integrity: sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==}
 
   clone@1.0.4:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
@@ -2427,6 +2552,10 @@ packages:
     resolution: {integrity: sha512-oj7KWToJuuxlPr7VV0vabvxEIiqNMo+q0NueIiL3XhtwC6FVOX7Hr1c0C4eD0bmf7Zr+S/dSf2xvkH3Ad6sU3Q==}
     engines: {node: '>=20'}
 
+  decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+
   dedent@1.7.2:
     resolution: {integrity: sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==}
     peerDependencies:
@@ -2444,6 +2573,10 @@ packages:
 
   defaults@1.0.4:
     resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
+
+  defer-to-connect@2.0.1:
+    resolution: {integrity: sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==}
+    engines: {node: '>=10'}
 
   define-lazy-prop@2.0.0:
     resolution: {integrity: sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==}
@@ -2658,6 +2791,9 @@ packages:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
 
+  eventemitter3@4.0.7:
+    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+
   events-universal@1.0.1:
     resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
 
@@ -2820,6 +2956,9 @@ packages:
   forever-agent@0.6.1:
     resolution: {integrity: sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==}
 
+  form-data-encoder@1.7.2:
+    resolution: {integrity: sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==}
+
   form-data-encoder@4.1.0:
     resolution: {integrity: sha512-G6NsmEW15s0Uw9XnCg+33H3ViYRyiM0hMrMhhqQOR8NFc5GhYrI+6I3u7OTw7b91J2g8rtvMBZJDbcGb2YUniw==}
     engines: {node: '>= 18'}
@@ -2886,6 +3025,10 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
+  get-stream@5.2.0:
+    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
+    engines: {node: '>=8'}
+
   get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
@@ -2908,6 +3051,11 @@ packages:
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
+
+  glob@10.0.0:
+    resolution: {integrity: sha512-zmp9ZDC6NpDNLujV2W2n+3lH+BafIVZ4/ct+Yj3BMZTH/+bgm/eVjHzeFLwxJrrIGgjjS2eiQLlpurHsNlEAtQ==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
@@ -2934,13 +3082,13 @@ packages:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
 
+  got-cjs@12.5.4:
+    resolution: {integrity: sha512-Uas6lAsP8bRCt5WXGMhjFf/qEHTrm4v4qxGR02rLG2kdG9qedctvlkdwXVcDJ7Cs84X+r4dPU7vdwGjCaspXug==}
+    engines: {node: '>=12'}
+
   got@14.6.6:
     resolution: {integrity: sha512-QLV1qeYSo5l13mQzWgP/y0LbMr5Plr5fJilgAIwgnwseproEbtNym8xpLsDzeZ6MWXgNE6kdWGBjdh3zT/Qerg==}
     engines: {node: '>=20'}
-
-  got@15.1.0:
-    resolution: {integrity: sha512-DG+DAAkRtno+oDr/GBsliAkhN9+zczOPM5qXk3efDZY3qvyRnZU+NwQlb/IOY6cSnxxTR9z3aHCcShJyjb0hJA==}
-    engines: {node: '>=22'}
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
@@ -3403,12 +3551,12 @@ packages:
     resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
     hasBin: true
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.1.1:
+    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
-  js-yaml@5.2.2:
-    resolution: {integrity: sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==}
+  js-yaml@4.3.0:
+    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
 
   jsbn@0.1.1:
@@ -3418,6 +3566,12 @@ packages:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
     engines: {node: '>=6'}
     hasBin: true
+
+  jsii-docgen@10.12.5:
+    resolution: {integrity: sha512-u0xKNxyaDY8Gbfs7hM761OsHr8xoRrJn+2iVCgJ6VvKTW0iDJ0bWHZdCv1ETrKAZdfE7sMy+2OoGL0+J9czgRQ==}
+    hasBin: true
+    peerDependencies:
+      jsii-rosetta: ^1.85.0 || ~5.0.14 || ~5.1.2 || ~5.2.0 || ~5.3.0 || ~5.4.0 || ~5.5.0 || ~5.6.0 || ~5.7.0 || ~5.8.0 || ~5.9.1 || ~6.0.0
 
   jsii-pacmak@1.139.0:
     resolution: {integrity: sha512-hE+rc+RS4Qwe+MzGqG515tXueOhn6r++/L8kpX5wT18HqUoBJdOdqFOv90PYitDgNywovOE0kEd8YyV1S5Mh6Q==}
@@ -3458,6 +3612,10 @@ packages:
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  json-stream-stringify@3.1.7:
+    resolution: {integrity: sha512-F4MWetLtY42YMaAKw5cV4e47zMD5aOT+tjjQWjX18ACtdkQ5Y/vrcfbcQ107Rh+MXjOCIx4KhW0wPmOvG8iQ5w==}
+    engines: {node: '>=7.10.1'}
 
   json-stringify-safe@5.0.1:
     resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
@@ -3579,13 +3737,13 @@ packages:
     resolution: {integrity: sha512-2+x8esE/Wb9SQ1F9IHaYWfsC9FIecLOPrK4g17FGEayjUWH172H6nwicRovGvSE2CPZouc2MCIqCI7h9d+GftQ==}
     engines: {node: '>=4'}
 
+  lowercase-keys@2.0.0:
+    resolution: {integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==}
+    engines: {node: '>=8'}
+
   lowercase-keys@3.0.0:
     resolution: {integrity: sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
-  lowercase-keys@4.0.1:
-    resolution: {integrity: sha512-wI9Nui/L8VfADa/cr/7NQruaASk1k23/Uh1khQ02BCVYiiy8F4AhOGnQzJy3Fl/c44GnYSbZHv8g7EcG3kJ1Qg==}
-    engines: {node: '>=20'}
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
@@ -3666,6 +3824,14 @@ packages:
     resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
     engines: {node: '>=12'}
 
+  mimic-response@1.0.1:
+    resolution: {integrity: sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==}
+    engines: {node: '>=4'}
+
+  mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+
   mimic-response@4.0.0:
     resolution: {integrity: sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -3677,12 +3843,20 @@ packages:
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
+  minimatch@7.4.9:
+    resolution: {integrity: sha512-Brg/fp/iAVDOQoHxkuN5bEYhyQlZhxddI78yWsCbeEwTHXQjlNLtiJDUsp1GIptVqMI7/gkJMz4vVAc01mpoBw==}
+    engines: {node: '>=10'}
+
   minimatch@9.0.9:
     resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
     engines: {node: '>=16 || 14 >=14.17'}
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  minipass@5.0.0:
+    resolution: {integrity: sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==}
+    engines: {node: '>=8'}
 
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
@@ -3737,6 +3911,10 @@ packages:
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
+
+  normalize-url@6.1.0:
+    resolution: {integrity: sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==}
+    engines: {node: '>=10'}
 
   normalize-url@8.1.1:
     resolution: {integrity: sha512-JYc0DPlpGWB40kH5g07gGTrYuMqV653k3uBKY6uITPWds3M0ov3GaWGp9lbE3Bzngx8+XkfzgvASb9vk9JDFXQ==}
@@ -3816,6 +3994,10 @@ packages:
   oxc-resolver@11.24.2:
     resolution: {integrity: sha512-FY91FiDBj7ls5MsFS9jN3tjz2o0/zsdSsymlakySaBwVJZorHhkWyICLZMKxlu1R9vYo+sd3z1jwb4J8x7bNDw==}
 
+  p-cancelable@2.1.1:
+    resolution: {integrity: sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==}
+    engines: {node: '>=8'}
+
   p-cancelable@4.0.1:
     resolution: {integrity: sha512-wBowNApzd45EIKdO1LaU+LrMBwAcjfPaYtVzV3lmfM3gf8Z4CHZsiIqlM8TZZ8okYvh5A1cP6gTfCRQtwUpaUg==}
     engines: {node: '>=14.16'}
@@ -3823,6 +4005,10 @@ packages:
   p-event@6.0.1:
     resolution: {integrity: sha512-Q6Bekk5wpzW5qIyUP4gdMEujObYstZl6DMMOSenwBvV0BlE5LkDwkjs5yHbZmdCEq2o4RJx4tE1vwxFVf2FG1w==}
     engines: {node: '>=16.17'}
+
+  p-finally@1.0.0:
+    resolution: {integrity: sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==}
+    engines: {node: '>=4'}
 
   p-limit@2.3.0:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
@@ -3839,6 +4025,14 @@ packages:
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
+
+  p-queue@6.6.2:
+    resolution: {integrity: sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==}
+    engines: {node: '>=8'}
+
+  p-timeout@3.2.0:
+    resolution: {integrity: sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==}
+    engines: {node: '>=8'}
 
   p-timeout@6.1.4:
     resolution: {integrity: sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==}
@@ -3990,8 +4184,15 @@ packages:
     resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
     engines: {node: '>=10'}
 
+  publib@0.2.1057:
+    resolution: {integrity: sha512-xCSsfTIDSelaMny+xK415Xdn3XJn/by7V5Yus2Ofm35IkvTYsOP+1ELEIcEqR87bJ2aHNT3kkC+s1up0xJCwKg==}
+    hasBin: true
+
   pump@2.0.1:
     resolution: {integrity: sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==}
+
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
   pumpify@1.5.1:
     resolution: {integrity: sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==}
@@ -4100,6 +4301,9 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
+  responselike@2.0.1:
+    resolution: {integrity: sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==}
+
   responselike@4.0.2:
     resolution: {integrity: sha512-cGk8IbWEAnaCpdAt1BHzJ3Ahz5ewDJa0KseTsE3qIRMJ3C698W8psM7byCeWVpd/Ha7FUYzuRVzXoKoM6nRUbA==}
     engines: {node: '>=20'}
@@ -4158,6 +4362,11 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  semver@7.8.2:
+    resolution: {integrity: sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   semver@7.8.4:
     resolution: {integrity: sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==}
     engines: {node: '>=10'}
@@ -4186,6 +4395,9 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  shlex@2.1.2:
+    resolution: {integrity: sha512-Nz6gtibMVgYeMEhUjp2KuwAgqaJA1K155dU/HuDaEJUGgnmYfVtVZah+uerVWdH8UGnyahhDCgABbYTbs254+w==}
 
   side-channel-list@1.0.1:
     resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
@@ -4377,10 +4589,6 @@ packages:
     resolution: {integrity: sha512-0OJWD12D7XX3KUg1DYkMaTTjSTo2k/mhIYI3HlBlceXSMcJhW/1qO735fPKS5prcyjvn57Ub151vvASYXpQrEw==}
     engines: {node: '>=18'}
 
-  tagged-tag@1.0.0:
-    resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
-    engines: {node: '>=20'}
-
   tar-stream@2.2.0:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
@@ -4527,10 +4735,6 @@ packages:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
 
-  type-fest@5.8.0:
-    resolution: {integrity: sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==}
-    engines: {node: '>=20'}
-
   type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
     engines: {node: '>= 0.6'}
@@ -4619,6 +4823,11 @@ packages:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
+  uuid@8.3.2:
+    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+    hasBin: true
+
   v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
 
@@ -4634,17 +4843,17 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
-  verdaccio-audit@13.1.0:
-    resolution: {integrity: sha512-Ydm3TElNWlbfZ34GZZXBJ8lz3gQzyVaoicyZcnRXDxF0WIiAixn186OVJFRjtBU3POdM0VfUnuq6e7+6uqWxxg==}
-    engines: {node: '>=22'}
+  verdaccio-audit@13.0.3:
+    resolution: {integrity: sha512-n5VYOooGpXr3ZE2DjNx6lJPkCFd2sORDVMmbs0o7Mqx6g0kOHTkfkY5DygZAwOvGtFy0CecufRrl49RzAD9Jkg==}
+    engines: {node: '>=18'}
 
-  verdaccio-htpasswd@13.1.0:
-    resolution: {integrity: sha512-KyZtp5T0aHO29ucA9MzdekVwk88VyOGJp29jI6l7sQw3C7bb1LN27SevInUmwUq39Ejel/qaMJbFmhdCUBLD2w==}
-    engines: {node: '>=22'}
+  verdaccio-htpasswd@13.0.3:
+    resolution: {integrity: sha512-xh0VO4zRfcbIR2bpH2SwW4kLHzCEKFYg9lykpuEENJ9OIcoc12mGXH5DTuOuJ9po8Y0mGTzFh3JUZIwXJlmOSw==}
+    engines: {node: '>=18'}
 
-  verdaccio@6.9.0:
-    resolution: {integrity: sha512-4IwEIW4gCDshroIS9OV/Yh4cSJxG1XImTPrmVwFAqQOthI/Er9HPDESmbPj4U0LayhWhAVCISh9ni6m98h33nQ==}
-    engines: {node: '>=22'}
+  verdaccio@6.7.4:
+    resolution: {integrity: sha512-C59DdKYtc1vayM3HiRFVRCRJMd4Hq4QCQnjTMM6CVanJvMpaqHlZ+DHE31/L8ScXkzUl1oS0HulizpxmMXW1LA==}
+    engines: {node: '>=20'}
     hasBin: true
 
   verror@1.10.0:
@@ -4725,9 +4934,17 @@ packages:
     engines: {node: '>= 14.6'}
     hasBin: true
 
+  yargs-parser@20.2.9:
+    resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
+    engines: {node: '>=10'}
+
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
+
+  yargs@16.2.2:
+    resolution: {integrity: sha512-Nt9ZJjXTv5R8MHbqby/wXQ6Gi0Bb3TcYZkR1bzuL4yB2OxWPkXknz513gEF0GoA6tn00UpbPvERW8rzCuWCA6w==}
+    engines: {node: '>=10'}
 
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
@@ -4753,7 +4970,184 @@ packages:
     resolution: {integrity: sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg==}
     engines: {node: '>=18'}
 
+  zx@8.8.5:
+    resolution: {integrity: sha512-SNgDF5L0gfN7FwVOdEFguY3orU5AkfFZm9B5YSHog/UDHv+lvmd82ZAsOenOkQixigwH2+yyH198AwNdKhj+RA==}
+    engines: {node: '>= 12.17.0'}
+    hasBin: true
+
 snapshots:
+
+  '@aws-sdk/client-codeartifact@3.1101.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/credential-provider-node': 3.972.76
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/fetch-http-handler': 5.6.13
+      '@smithy/node-http-handler': 4.9.13
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/core@3.977.4':
+    dependencies:
+      '@aws-sdk/types': 3.974.2
+      '@aws-sdk/xml-builder': 3.972.37
+      '@aws/lambda-invoke-store': 0.3.0
+      '@smithy/core': 3.31.1
+      '@smithy/signature-v4': 5.6.12
+      '@smithy/types': 4.16.1
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-cognito-identity@3.972.64':
+    dependencies:
+      '@aws-sdk/nested-clients': 3.997.39
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.65':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.67':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/fetch-http-handler': 5.6.13
+      '@smithy/node-http-handler': 4.9.13
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.973.10':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/credential-provider-env': 3.972.65
+      '@aws-sdk/credential-provider-http': 3.972.67
+      '@aws-sdk/credential-provider-login': 3.972.72
+      '@aws-sdk/credential-provider-process': 3.972.65
+      '@aws-sdk/credential-provider-sso': 3.973.9
+      '@aws-sdk/credential-provider-web-identity': 3.972.71
+      '@aws-sdk/nested-clients': 3.997.39
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/credential-provider-imds': 4.4.16
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.72':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/nested-clients': 3.997.39
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-node@3.972.76':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.65
+      '@aws-sdk/credential-provider-http': 3.972.67
+      '@aws-sdk/credential-provider-ini': 3.973.10
+      '@aws-sdk/credential-provider-process': 3.972.65
+      '@aws-sdk/credential-provider-sso': 3.973.9
+      '@aws-sdk/credential-provider-web-identity': 3.972.71
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/credential-provider-imds': 4.4.16
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.65':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.973.9':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/nested-clients': 3.997.39
+      '@aws-sdk/token-providers': 3.1100.0
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.71':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/nested-clients': 3.997.39
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-providers@3.1101.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/credential-provider-cognito-identity': 3.972.64
+      '@aws-sdk/credential-provider-env': 3.972.65
+      '@aws-sdk/credential-provider-http': 3.972.67
+      '@aws-sdk/credential-provider-ini': 3.973.10
+      '@aws-sdk/credential-provider-login': 3.972.72
+      '@aws-sdk/credential-provider-node': 3.972.76
+      '@aws-sdk/credential-provider-process': 3.972.65
+      '@aws-sdk/credential-provider-sso': 3.973.9
+      '@aws-sdk/credential-provider-web-identity': 3.972.71
+      '@aws-sdk/nested-clients': 3.997.39
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/credential-provider-imds': 4.4.16
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.39':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/signature-v4-multi-region': 3.996.43
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/fetch-http-handler': 5.6.13
+      '@smithy/node-http-handler': 4.9.13
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.43':
+    dependencies:
+      '@aws-sdk/types': 3.974.2
+      '@smithy/signature-v4': 5.6.12
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1100.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/nested-clients': 3.997.39
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.974.2':
+    dependencies:
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.37':
+    dependencies:
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.3.0': {}
 
   '@babel/code-frame@7.29.7':
     dependencies:
@@ -5554,7 +5948,7 @@ snapshots:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
-  '@cypress/request@4.0.1':
+  '@cypress/request@3.0.10':
     dependencies:
       aws-sign2: 0.7.0
       aws4: 1.13.2
@@ -5569,10 +5963,11 @@ snapshots:
       json-stringify-safe: 5.0.1
       mime-types: 2.1.35
       performance-now: 2.1.0
-      qs: 6.15.3
+      qs: 6.14.2
       safe-buffer: 5.2.1
       tough-cookie: 5.1.2
       tunnel-agent: 0.6.0
+      uuid: 8.3.2
 
   '@emnapi/core@1.10.0':
     dependencies:
@@ -6166,10 +6561,10 @@ snapshots:
       yaml: 2.9.0
       yargs-parser: 21.1.1
 
-  '@nx/eslint-plugin@23.1.0(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@6.0.3))(@swc/cli@0.8.1(@swc/core@1.15.8(@swc/helpers@0.5.18)))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@typescript-eslint/parser@8.65.0(eslint@9.39.5)(typescript@6.0.3))(eslint-config-prettier@10.1.8(eslint@9.39.5))(eslint@9.39.5)(nx@23.1.0(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@6.0.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(typescript@6.0.3)(verdaccio@6.9.0(typanion@3.14.0))':
+  '@nx/eslint-plugin@23.1.0(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@6.0.3))(@swc/cli@0.8.1(@swc/core@1.15.8(@swc/helpers@0.5.18)))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@typescript-eslint/parser@8.65.0(eslint@9.39.5)(typescript@6.0.3))(eslint-config-prettier@10.1.8(eslint@9.39.5))(eslint@9.39.5)(nx@23.1.0(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@6.0.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(typescript@6.0.3)(verdaccio@6.7.4(typanion@3.14.0))':
     dependencies:
       '@nx/devkit': 23.1.0(nx@23.1.0(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@6.0.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))
-      '@nx/js': 23.1.0(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@6.0.3))(@swc/cli@0.8.1(@swc/core@1.15.8(@swc/helpers@0.5.18)))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@23.1.0(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@6.0.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.9.0(typanion@3.14.0))
+      '@nx/js': 23.1.0(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@6.0.3))(@swc/cli@0.8.1(@swc/core@1.15.8(@swc/helpers@0.5.18)))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@23.1.0(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@6.0.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.7.4(typanion@3.14.0))
       '@phenomnomnominal/tsquery': 6.2.0(typescript@6.0.3)
       '@typescript-eslint/type-utils': 8.65.0(eslint@9.39.5)(typescript@6.0.3)
       '@typescript-eslint/utils': 8.65.0(eslint@9.39.5)(typescript@6.0.3)
@@ -6193,16 +6588,16 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/eslint@23.1.0(@babel/traverse@7.29.7)(@nx/jest@23.1.0(ddb785a3f7d67d276dfea5db0c3ebae1))(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@6.0.3))(@swc/cli@0.8.1(@swc/core@1.15.8(@swc/helpers@0.5.18)))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(eslint@9.39.5)(nx@23.1.0(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@6.0.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.9.0(typanion@3.14.0))':
+  '@nx/eslint@23.1.0(@babel/traverse@7.29.7)(@nx/jest@23.1.0(5c506a22c4dc7197bda76a9c56e40cf7))(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@6.0.3))(@swc/cli@0.8.1(@swc/core@1.15.8(@swc/helpers@0.5.18)))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(eslint@9.39.5)(nx@23.1.0(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@6.0.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.7.4(typanion@3.14.0))':
     dependencies:
       '@nx/devkit': 23.1.0(nx@23.1.0(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@6.0.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))
-      '@nx/js': 23.1.0(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@6.0.3))(@swc/cli@0.8.1(@swc/core@1.15.8(@swc/helpers@0.5.18)))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@23.1.0(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@6.0.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.9.0(typanion@3.14.0))
+      '@nx/js': 23.1.0(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@6.0.3))(@swc/cli@0.8.1(@swc/core@1.15.8(@swc/helpers@0.5.18)))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@23.1.0(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@6.0.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.7.4(typanion@3.14.0))
       eslint: 9.39.5
       semver: 7.8.5
       tslib: 2.8.1
       typescript: 6.0.3
     optionalDependencies:
-      '@nx/jest': 23.1.0(ddb785a3f7d67d276dfea5db0c3ebae1)
+      '@nx/jest': 23.1.0(5c506a22c4dc7197bda76a9c56e40cf7)
       '@zkochan/js-yaml': 0.0.7
     transitivePeerDependencies:
       - '@babel/traverse'
@@ -6213,12 +6608,12 @@ snapshots:
       - supports-color
       - verdaccio
 
-  '@nx/jest@23.1.0(ddb785a3f7d67d276dfea5db0c3ebae1)':
+  '@nx/jest@23.1.0(5c506a22c4dc7197bda76a9c56e40cf7)':
     dependencies:
       '@jest/reporters': 30.4.1
       '@jest/test-result': 30.4.1
       '@nx/devkit': 23.1.0(nx@23.1.0(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@6.0.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))
-      '@nx/js': 23.1.0(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@6.0.3))(@swc/cli@0.8.1(@swc/core@1.15.8(@swc/helpers@0.5.18)))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@23.1.0(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@6.0.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.9.0(typanion@3.14.0))
+      '@nx/js': 23.1.0(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@6.0.3))(@swc/cli@0.8.1(@swc/core@1.15.8(@swc/helpers@0.5.18)))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@23.1.0(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@6.0.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.7.4(typanion@3.14.0))
       '@phenomnomnominal/tsquery': 6.2.0(typescript@6.0.3)
       identity-obj-proxy: 3.0.0
       jest-config: 30.4.2(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@24.13.3)(typescript@6.0.3))
@@ -6249,7 +6644,7 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/js@23.1.0(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@6.0.3))(@swc/cli@0.8.1(@swc/core@1.15.8(@swc/helpers@0.5.18)))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@23.1.0(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@6.0.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.9.0(typanion@3.14.0))':
+  '@nx/js@23.1.0(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@6.0.3))(@swc/cli@0.8.1(@swc/core@1.15.8(@swc/helpers@0.5.18)))(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@23.1.0(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.27)(typescript@6.0.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(verdaccio@6.7.4(typanion@3.14.0))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-proposal-decorators': 7.29.7(@babel/core@7.29.7)
@@ -6279,7 +6674,7 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@swc/cli': 0.8.1(@swc/core@1.15.8(@swc/helpers@0.5.18))
-      verdaccio: 6.9.0(typanion@3.14.0)
+      verdaccio: 6.7.4(typanion@3.14.0)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -6410,9 +6805,9 @@ snapshots:
 
   '@sinclair/typebox@0.34.52': {}
 
-  '@sindresorhus/is@7.2.0': {}
+  '@sindresorhus/is@4.6.0': {}
 
-  '@sindresorhus/is@8.1.0': {}
+  '@sindresorhus/is@7.2.0': {}
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
@@ -6423,6 +6818,39 @@ snapshots:
   '@sinonjs/fake-timers@15.4.0':
     dependencies:
       '@sinonjs/commons': 3.0.1
+
+  '@smithy/core@3.31.1':
+    dependencies:
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.4.16':
+    dependencies:
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.6.13':
+    dependencies:
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.9.13':
+    dependencies:
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.6.12':
+    dependencies:
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/types@4.16.1':
+    dependencies:
+      tslib: 2.8.1
 
   '@swc-node/core@1.15.0(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.27)':
     dependencies:
@@ -6530,6 +6958,10 @@ snapshots:
     dependencies:
       '@swc/counter': 0.1.3
 
+  '@szmarczak/http-timer@4.0.6':
+    dependencies:
+      defer-to-connect: 2.0.1
+
   '@tokenizer/inflate@0.4.1':
     dependencies:
       debug: 4.4.3(supports-color@7.2.0)
@@ -6583,6 +7015,10 @@ snapshots:
 
   '@types/estree@1.0.9': {}
 
+  '@types/fs-extra@8.1.5':
+    dependencies:
+      '@types/node': 24.13.3
+
   '@types/http-cache-semantics@4.2.0': {}
 
   '@types/istanbul-lib-coverage@2.0.6': {}
@@ -6607,6 +7043,10 @@ snapshots:
       undici-types: 7.18.2
 
   '@types/parse-json@4.0.2': {}
+
+  '@types/responselike@1.0.0':
+    dependencies:
+      '@types/node': 24.13.3
 
   '@types/stack-utils@2.0.3': {}
 
@@ -6779,63 +7219,63 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.12.2':
     optional: true
 
-  '@verdaccio/auth@8.1.0':
+  '@verdaccio/auth@8.0.4':
     dependencies:
-      '@verdaccio/config': 8.2.0
-      '@verdaccio/core': 8.2.0
-      '@verdaccio/loaders': 8.1.0
-      '@verdaccio/signature': 8.1.0
+      '@verdaccio/config': 8.1.2
+      '@verdaccio/core': 8.1.2
+      '@verdaccio/loaders': 8.0.3
+      '@verdaccio/signature': 8.0.3
       debug: 4.4.3(supports-color@7.2.0)
       lodash: 4.18.1
-      verdaccio-htpasswd: 13.1.0
+      verdaccio-htpasswd: 13.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@verdaccio/config@8.2.0':
+  '@verdaccio/config@8.1.2':
     dependencies:
-      '@verdaccio/core': 8.2.0
+      '@verdaccio/core': 8.1.2
       debug: 4.4.3(supports-color@7.2.0)
-      js-yaml: 5.2.2
+      js-yaml: 4.1.1
       lodash: 4.18.1
     transitivePeerDependencies:
       - supports-color
 
-  '@verdaccio/core@8.2.0':
+  '@verdaccio/core@8.1.2':
     dependencies:
       ajv: 8.18.0
       http-errors: 2.0.1
       http-status-codes: 2.3.0
-      minimatch: 10.2.5
+      minimatch: 7.4.9
       process-warning: 1.0.0
       semver: 7.7.4
 
-  '@verdaccio/file-locking@13.1.0':
+  '@verdaccio/file-locking@13.0.1':
     dependencies:
       lockfile: 1.0.4
 
-  '@verdaccio/hooks@8.1.1':
+  '@verdaccio/hooks@8.0.3':
     dependencies:
-      '@verdaccio/core': 8.2.0
-      '@verdaccio/logger': 8.1.0
+      '@verdaccio/core': 8.1.2
+      '@verdaccio/logger': 8.0.3
       debug: 4.4.3(supports-color@7.2.0)
-      got: 15.1.0
+      got-cjs: 12.5.4
       handlebars: 4.7.9
     transitivePeerDependencies:
       - supports-color
 
-  '@verdaccio/loaders@8.1.0':
+  '@verdaccio/loaders@8.0.3':
     dependencies:
-      '@verdaccio/core': 8.2.0
+      '@verdaccio/core': 8.1.2
       debug: 4.4.3(supports-color@7.2.0)
       lodash: 4.18.1
     transitivePeerDependencies:
       - supports-color
 
-  '@verdaccio/local-storage-legacy@11.4.0':
+  '@verdaccio/local-storage-legacy@11.3.4':
     dependencies:
-      '@verdaccio/core': 8.2.0
-      '@verdaccio/file-locking': 13.1.0
-      '@verdaccio/streams': 10.3.0
+      '@verdaccio/core': 8.1.2
+      '@verdaccio/file-locking': 13.0.1
+      '@verdaccio/streams': 10.2.5
       debug: 4.4.3(supports-color@7.2.0)
       globby: 11.1.0
       lodash: 4.18.1
@@ -6845,16 +7285,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@verdaccio/logger-commons@8.1.0':
+  '@verdaccio/logger-commons@8.0.3':
     dependencies:
-      '@verdaccio/core': 8.2.0
-      '@verdaccio/logger-prettify': 8.1.0
+      '@verdaccio/core': 8.1.2
+      '@verdaccio/logger-prettify': 8.0.1
       colorette: 2.0.20
       debug: 4.4.3(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@verdaccio/logger-prettify@8.1.0':
+  '@verdaccio/logger-prettify@8.0.1':
     dependencies:
       colorette: 2.0.20
       dayjs: 1.11.18
@@ -6863,18 +7303,18 @@ snapshots:
       pino-abstract-transport: 1.2.0
       sonic-boom: 3.8.1
 
-  '@verdaccio/logger@8.1.0':
+  '@verdaccio/logger@8.0.3':
     dependencies:
-      '@verdaccio/logger-commons': 8.1.0
+      '@verdaccio/logger-commons': 8.0.3
       pino: 9.14.0
     transitivePeerDependencies:
       - supports-color
 
-  '@verdaccio/middleware@8.1.0':
+  '@verdaccio/middleware@8.0.5':
     dependencies:
-      '@verdaccio/config': 8.2.0
-      '@verdaccio/core': 8.2.0
-      '@verdaccio/url': 13.1.0
+      '@verdaccio/config': 8.1.2
+      '@verdaccio/core': 8.1.2
+      '@verdaccio/url': 13.0.3
       debug: 4.4.3(supports-color@7.2.0)
       express: 4.22.1
       express-rate-limit: 5.5.1
@@ -6883,36 +7323,36 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@verdaccio/package-filter@13.1.0':
+  '@verdaccio/package-filter@13.0.3':
     dependencies:
-      '@verdaccio/core': 8.2.0
+      '@verdaccio/core': 8.1.2
       debug: 4.4.3(supports-color@7.2.0)
       semver: 7.7.4
     transitivePeerDependencies:
       - supports-color
 
-  '@verdaccio/search-indexer@8.1.0':
+  '@verdaccio/search-indexer@8.0.2':
     dependencies:
       debug: 4.4.3(supports-color@7.2.0)
       fuse.js: 7.3.0
     transitivePeerDependencies:
       - supports-color
 
-  '@verdaccio/signature@8.1.0':
+  '@verdaccio/signature@8.0.3':
     dependencies:
-      '@verdaccio/config': 8.2.0
-      '@verdaccio/core': 8.2.0
+      '@verdaccio/config': 8.1.2
+      '@verdaccio/core': 8.1.2
       debug: 4.4.3(supports-color@7.2.0)
       jsonwebtoken: 9.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@verdaccio/streams@10.3.0': {}
+  '@verdaccio/streams@10.2.5': {}
 
-  '@verdaccio/tarball@13.1.0':
+  '@verdaccio/tarball@13.0.3':
     dependencies:
-      '@verdaccio/core': 8.2.0
-      '@verdaccio/url': 13.1.0
+      '@verdaccio/core': 8.1.2
+      '@verdaccio/url': 13.0.3
       debug: 4.4.3(supports-color@7.2.0)
       gunzip-maybe: 1.4.2
       tar-stream: 3.1.7
@@ -6921,25 +7361,25 @@ snapshots:
       - react-native-b4a
       - supports-color
 
-  '@verdaccio/ui-theme@9.0.0-next-9.21':
+  '@verdaccio/ui-theme@9.0.0-next-9.20':
     dependencies:
       debug: 4.4.3(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@verdaccio/url@13.1.0':
+  '@verdaccio/url@13.0.3':
     dependencies:
-      '@verdaccio/core': 8.2.0
+      '@verdaccio/core': 8.1.2
       debug: 4.4.3(supports-color@7.2.0)
       validator: 13.15.26
     transitivePeerDependencies:
       - supports-color
 
-  '@verdaccio/utils@8.2.0':
+  '@verdaccio/utils@8.1.3':
     dependencies:
-      '@verdaccio/core': 8.2.0
+      '@verdaccio/core': 8.1.2
       lodash: 4.18.1
-      minimatch: 10.2.5
+      minimatch: 7.4.9
 
   '@xhmikosr/archive-type@8.1.0':
     dependencies:
@@ -7332,6 +7772,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  bowser@2.14.1: {}
+
   brace-expansion@1.1.16:
     dependencies:
       balanced-match: 1.0.2
@@ -7387,6 +7829,8 @@ snapshots:
 
   bytes@3.1.2: {}
 
+  cacheable-lookup@6.1.0: {}
+
   cacheable-lookup@7.0.0: {}
 
   cacheable-request@13.0.19:
@@ -7398,6 +7842,16 @@ snapshots:
       mimic-response: 4.0.0
       normalize-url: 8.1.1
       responselike: 4.0.2
+
+  cacheable-request@7.0.2:
+    dependencies:
+      clone-response: 1.0.3
+      get-stream: 5.2.0
+      http-cache-semantics: 4.2.0
+      keyv: 4.5.4
+      lowercase-keys: 2.0.0
+      normalize-url: 6.1.0
+      responselike: 2.0.1
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -7428,8 +7882,6 @@ snapshots:
 
   char-regex@1.0.2: {}
 
-  chunk-data@0.1.0: {}
-
   ci-info@4.4.0: {}
 
   cjs-module-lexer@2.2.0: {}
@@ -7444,11 +7896,21 @@ snapshots:
     dependencies:
       typanion: 3.14.0
 
+  cliui@7.0.4:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
   cliui@8.0.1:
     dependencies:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
+
+  clone-response@1.0.3:
+    dependencies:
+      mimic-response: 1.0.1
 
   clone@1.0.4: {}
 
@@ -7582,6 +8044,10 @@ snapshots:
     dependencies:
       mimic-response: 4.0.0
 
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+
   dedent@1.7.2(babel-plugin-macros@3.1.0):
     optionalDependencies:
       babel-plugin-macros: 3.1.0
@@ -7593,6 +8059,8 @@ snapshots:
   defaults@1.0.4:
     dependencies:
       clone: 1.0.4
+
+  defer-to-connect@2.0.1: {}
 
   define-lazy-prop@2.0.0: {}
 
@@ -7786,6 +8254,8 @@ snapshots:
   etag@1.8.1: {}
 
   event-target-shim@5.0.1: {}
+
+  eventemitter3@4.0.7: {}
 
   events-universal@1.0.1:
     dependencies:
@@ -8049,6 +8519,8 @@ snapshots:
 
   forever-agent@0.6.1: {}
 
+  form-data-encoder@1.7.2: {}
+
   form-data-encoder@4.1.0: {}
 
   form-data@4.0.6:
@@ -8112,6 +8584,10 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
 
+  get-stream@5.2.0:
+    dependencies:
+      pump: 3.0.4
+
   get-stream@6.0.1: {}
 
   get-stream@8.0.1: {}
@@ -8132,6 +8608,13 @@ snapshots:
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
+
+  glob@10.0.0:
+    dependencies:
+      fs.realpath: 1.0.0
+      minimatch: 9.0.9
+      minipass: 5.0.0
+      path-scurry: 1.11.1
 
   glob@10.5.0:
     dependencies:
@@ -8166,6 +8649,21 @@ snapshots:
 
   gopd@1.2.0: {}
 
+  got-cjs@12.5.4:
+    dependencies:
+      '@sindresorhus/is': 4.6.0
+      '@szmarczak/http-timer': 4.0.6
+      '@types/responselike': 1.0.0
+      cacheable-lookup: 6.1.0
+      cacheable-request: 7.0.2
+      decompress-response: 6.0.0
+      form-data-encoder: 1.7.2
+      get-stream: 6.0.1
+      http2-wrapper: 2.2.1
+      lowercase-keys: 2.0.0
+      p-cancelable: 2.1.1
+      responselike: 2.0.1
+
   got@14.6.6:
     dependencies:
       '@sindresorhus/is': 7.2.0
@@ -8180,21 +8678,6 @@ snapshots:
       p-cancelable: 4.0.1
       responselike: 4.0.2
       type-fest: 4.41.0
-
-  got@15.1.0:
-    dependencies:
-      '@sindresorhus/is': 8.1.0
-      byte-counter: 0.1.0
-      cacheable-lookup: 7.0.0
-      cacheable-request: 13.0.19
-      chunk-data: 0.1.0
-      decompress-response: 10.0.0
-      http2-wrapper: 2.2.1
-      keyv: 5.6.0
-      lowercase-keys: 4.0.1
-      responselike: 4.0.2
-      type-fest: 5.8.0
-      uint8array-extras: 1.5.0
 
   graceful-fs@4.2.11: {}
 
@@ -8471,7 +8954,7 @@ snapshots:
       jest-config: 30.3.0(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@24.13.3)(typescript@6.0.3))
       jest-util: 30.3.0
       jest-validate: 30.3.0
-      yargs: 17.7.2
+      yargs: 17.7.3
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -8987,17 +9470,29 @@ snapshots:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.3.0:
+  js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
 
-  js-yaml@5.2.2:
+  js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
 
   jsbn@0.1.1: {}
 
   jsesc@3.1.0: {}
+
+  jsii-docgen@10.12.5(jsii-rosetta@6.0.7):
+    dependencies:
+      '@jsii/spec': 1.139.0
+      case: 1.6.3
+      fast-glob: 3.3.3
+      fs-extra: 10.1.0
+      jsii-reflect: 1.139.0
+      jsii-rosetta: 6.0.7
+      json-stream-stringify: 3.1.7
+      semver: 7.8.5
+      yargs: 16.2.2
 
   jsii-pacmak@1.139.0(jsii-rosetta@6.0.7):
     dependencies:
@@ -9070,6 +9565,8 @@ snapshots:
   json-schema@0.4.0: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
+
+  json-stream-stringify@3.1.7: {}
 
   json-stringify-safe@5.0.1: {}
 
@@ -9205,9 +9702,9 @@ snapshots:
       pify: 3.0.0
       steno: 0.4.4
 
-  lowercase-keys@3.0.0: {}
+  lowercase-keys@2.0.0: {}
 
-  lowercase-keys@4.0.1: {}
+  lowercase-keys@3.0.0: {}
 
   lru-cache@10.4.3: {}
 
@@ -9266,6 +9763,10 @@ snapshots:
 
   mimic-fn@4.0.0: {}
 
+  mimic-response@1.0.1: {}
+
+  mimic-response@3.1.0: {}
+
   mimic-response@4.0.0: {}
 
   minimatch@10.2.5:
@@ -9276,11 +9777,17 @@ snapshots:
     dependencies:
       brace-expansion: 1.1.16
 
+  minimatch@7.4.9:
+    dependencies:
+      brace-expansion: 2.1.2
+
   minimatch@9.0.9:
     dependencies:
       brace-expansion: 2.1.2
 
   minimist@1.2.8: {}
+
+  minipass@5.0.0: {}
 
   minipass@7.1.3: {}
 
@@ -9309,6 +9816,8 @@ snapshots:
   node-releases@2.0.51: {}
 
   normalize-path@3.0.0: {}
+
+  normalize-url@6.1.0: {}
 
   normalize-url@8.1.1: {}
 
@@ -9531,11 +10040,15 @@ snapshots:
       '@oxc-resolver/binding-win32-arm64-msvc': 11.24.2
       '@oxc-resolver/binding-win32-x64-msvc': 11.24.2
 
+  p-cancelable@2.1.1: {}
+
   p-cancelable@4.0.1: {}
 
   p-event@6.0.1:
     dependencies:
       p-timeout: 6.1.4
+
+  p-finally@1.0.0: {}
 
   p-limit@2.3.0:
     dependencies:
@@ -9552,6 +10065,15 @@ snapshots:
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
+
+  p-queue@6.6.2:
+    dependencies:
+      eventemitter3: 4.0.7
+      p-timeout: 3.2.0
+
+  p-timeout@3.2.0:
+    dependencies:
+      p-finally: 1.0.0
 
   p-timeout@6.1.4: {}
 
@@ -9684,7 +10206,25 @@ snapshots:
 
   proxy-from-env@2.1.0: {}
 
+  publib@0.2.1057:
+    dependencies:
+      '@aws-sdk/client-codeartifact': 3.1101.0
+      '@aws-sdk/credential-providers': 3.1101.0
+      '@aws-sdk/types': 3.974.2
+      '@types/fs-extra': 8.1.5
+      fs-extra: 8.1.0
+      glob: 10.0.0
+      p-queue: 6.6.2
+      shlex: 2.1.2
+      yargs: 17.7.3
+      zx: 8.8.5
+
   pump@2.0.1:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+
+  pump@3.0.4:
     dependencies:
       end-of-stream: 1.4.5
       once: 1.4.0
@@ -9797,6 +10337,10 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
+  responselike@2.0.1:
+    dependencies:
+      lowercase-keys: 2.0.0
+
   responselike@4.0.2:
     dependencies:
       lowercase-keys: 3.0.0
@@ -9844,6 +10388,8 @@ snapshots:
 
   semver@7.7.4: {}
 
+  semver@7.8.2: {}
+
   semver@7.8.4: {}
 
   semver@7.8.5: {}
@@ -9882,6 +10428,8 @@ snapshots:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  shlex@2.1.2: {}
 
   side-channel-list@1.0.1:
     dependencies:
@@ -10089,8 +10637,6 @@ snapshots:
 
   system-architecture@1.0.0: {}
 
-  tagged-tag@1.0.0: {}
-
   tar-stream@2.2.0:
     dependencies:
       bl: 4.1.0
@@ -10242,10 +10788,6 @@ snapshots:
 
   type-fest@4.41.0: {}
 
-  type-fest@5.8.0:
-    dependencies:
-      tagged-tag: 1.0.0
-
   type-is@1.6.18:
     dependencies:
       media-typer: 0.3.0
@@ -10340,6 +10882,8 @@ snapshots:
 
   utils-merge@1.0.1: {}
 
+  uuid@8.3.2: {}
+
   v8-compile-cache-lib@3.0.1: {}
 
   v8-to-istanbul@9.3.0:
@@ -10352,10 +10896,10 @@ snapshots:
 
   vary@1.1.2: {}
 
-  verdaccio-audit@13.1.0:
+  verdaccio-audit@13.0.3:
     dependencies:
-      '@verdaccio/config': 8.2.0
-      '@verdaccio/core': 8.2.0
+      '@verdaccio/config': 8.1.2
+      '@verdaccio/core': 8.1.2
       express: 4.22.1
       https-proxy-agent: 5.0.1(supports-color@7.2.0)
       node-fetch: 2.6.7
@@ -10363,10 +10907,10 @@ snapshots:
       - encoding
       - supports-color
 
-  verdaccio-htpasswd@13.1.0:
+  verdaccio-htpasswd@13.0.3:
     dependencies:
-      '@verdaccio/core': 8.2.0
-      '@verdaccio/file-locking': 13.1.0
+      '@verdaccio/core': 8.1.2
+      '@verdaccio/file-locking': 13.0.1
       apache-md5: 1.1.8
       bcryptjs: 2.4.3
       debug: 4.4.3(supports-color@7.2.0)
@@ -10375,25 +10919,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  verdaccio@6.9.0(typanion@3.14.0):
+  verdaccio@6.7.4(typanion@3.14.0):
     dependencies:
-      '@cypress/request': 4.0.1
-      '@verdaccio/auth': 8.1.0
-      '@verdaccio/config': 8.2.0
-      '@verdaccio/core': 8.2.0
-      '@verdaccio/hooks': 8.1.1
-      '@verdaccio/loaders': 8.1.0
-      '@verdaccio/local-storage-legacy': 11.4.0
-      '@verdaccio/logger': 8.1.0
-      '@verdaccio/middleware': 8.1.0
-      '@verdaccio/package-filter': 13.1.0
-      '@verdaccio/search-indexer': 8.1.0
-      '@verdaccio/signature': 8.1.0
-      '@verdaccio/streams': 10.3.0
-      '@verdaccio/tarball': 13.1.0
-      '@verdaccio/ui-theme': 9.0.0-next-9.21
-      '@verdaccio/url': 13.1.0
-      '@verdaccio/utils': 8.2.0
+      '@cypress/request': 3.0.10
+      '@verdaccio/auth': 8.0.4
+      '@verdaccio/config': 8.1.2
+      '@verdaccio/core': 8.1.2
+      '@verdaccio/hooks': 8.0.3
+      '@verdaccio/loaders': 8.0.3
+      '@verdaccio/local-storage-legacy': 11.3.4
+      '@verdaccio/logger': 8.0.3
+      '@verdaccio/middleware': 8.0.5
+      '@verdaccio/package-filter': 13.0.3
+      '@verdaccio/search-indexer': 8.0.2
+      '@verdaccio/signature': 8.0.3
+      '@verdaccio/streams': 10.2.5
+      '@verdaccio/tarball': 13.0.3
+      '@verdaccio/ui-theme': 9.0.0-next-9.20
+      '@verdaccio/url': 13.0.3
+      '@verdaccio/utils': 8.1.3
       JSONStream: 1.3.5
       async: 3.2.6
       clipanion: 4.0.0-rc.4(typanion@3.14.0)
@@ -10405,9 +10949,9 @@ snapshots:
       lodash: 4.18.1
       lru-cache: 7.18.3
       mime: 3.0.0
-      semver: 7.8.5
-      verdaccio-audit: 13.1.0
-      verdaccio-htpasswd: 13.1.0
+      semver: 7.8.2
+      verdaccio-audit: 13.0.3
+      verdaccio-htpasswd: 13.0.3
     transitivePeerDependencies:
       - bare-abort-controller
       - encoding
@@ -10483,7 +11027,19 @@ snapshots:
 
   yaml@2.9.0: {}
 
+  yargs-parser@20.2.9: {}
+
   yargs-parser@21.1.1: {}
+
+  yargs@16.2.2:
+    dependencies:
+      cliui: 7.0.4
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 20.2.9
 
   yargs@17.7.2:
     dependencies:
@@ -10514,3 +11070,5 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yoctocolors@2.2.0: {}
+
+  zx@8.8.5: {}

--- a/project.json
+++ b/project.json
@@ -1,0 +1,24 @@
+{
+  "name": "@cdk-x/cdkx",
+  "$schema": "node_modules/nx/schemas/project-schema.json",
+  "targets": {
+    "release-local": {
+      "executor": "nx:run-commands",
+      "options": {
+        "parallel": false,
+        "env": {
+          "NPM_REGISTRY": "localhost:4873",
+          "DISABLE_HTTPS": "true",
+          "NPM_TOKEN": "local-verdaccio-fake-token"
+        },
+        "commands": [
+          "node tools/release-version.mjs --git-commit=false --git-tag=false --git-push=false --first-release",
+          "node tools/release-local-changelog.mjs",
+          "node tools/release-local-unpublish.mjs",
+          "nx run-many -t jsii-publish-npm",
+          "node tools/release-local-cleanup.mjs"
+        ]
+      }
+    }
+  }
+}

--- a/tools/list-release-projects.mjs
+++ b/tools/list-release-projects.mjs
@@ -1,0 +1,37 @@
+// Lists every jsii-publishable project (name + root dir + release phase) as a
+// JSON array on stdout, e.g.
+// [{"name":"core","root":"packages/core","phase":"alpha"}, ...].
+//
+// Used by the release workflow to build dynamic matrices (per-package publish
+// jobs) without ever having to hardcode/update a package list in the YAML as
+// new libraries are added to the workspace. `phase` (from each project's
+// `release.phase` in project.json, default "stable") drives the npm dist-tag:
+// a "stable" package publishes under npm's default "latest" tag, anything else
+// must publish under its own phase tag (NPM_DIST_TAG=<phase>) so a prerelease
+// never becomes what `npm install <pkg>` resolves to.
+//
+// Optional first arg: comma/space-separated Nx project names (e.g. "core") to
+// filter down to - mirrors the `projects` workflow_dispatch input, so a
+// first-release run can target just the new library instead of every project
+// with a jsii-publish-npm target.
+import { nxJson } from './nx-json.mjs';
+
+const filter = (process.argv[2] ?? '')
+  .split(/[\s,]+/)
+  .map((name) => name.trim())
+  .filter(Boolean);
+
+const projects = nxJson(['show', 'projects', '--with-target', 'jsii-publish-npm']).filter(
+  (project) => filter.length === 0 || filter.includes(project),
+);
+
+const result = projects.map((project) => {
+  const config = nxJson(['show', 'project', project]);
+  return {
+    name: config.root.split('/').pop(),
+    root: config.root,
+    phase: config.release?.phase ?? 'stable',
+  };
+});
+
+process.stdout.write(JSON.stringify(result));

--- a/tools/list-release-projects.mjs
+++ b/tools/list-release-projects.mjs
@@ -21,9 +21,12 @@ const filter = (process.argv[2] ?? '')
   .map((name) => name.trim())
   .filter(Boolean);
 
-const projects = nxJson(['show', 'projects', '--with-target', 'jsii-publish-npm']).filter(
-  (project) => filter.length === 0 || filter.includes(project),
-);
+const projects = nxJson([
+  'show',
+  'projects',
+  '--with-target',
+  'jsii-publish-npm',
+]).filter((project) => filter.length === 0 || filter.includes(project));
 
 const result = projects.map((project) => {
   const config = nxJson(['show', 'project', project]);

--- a/tools/nx-json.mjs
+++ b/tools/nx-json.mjs
@@ -1,0 +1,15 @@
+// Runs `nx <args> --json` and parses its output as JSON.
+//
+// Passes --silent to pnpm itself (before the nx args): pnpm's own reporter
+// prints a "Scope: all N workspace projects" line to stdout ahead of nx's
+// real output whenever it decides the invocation spans more than one
+// workspace package - observed on fresh CI runners (empty lockfile/store
+// verification cache) but not reliably on an already-warmed local machine.
+// --silent suppresses that reporter unconditionally, so stdout is always
+// exactly nx's own JSON.
+import { execFileSync } from 'node:child_process';
+
+export function nxJson(args) {
+  const stdout = execFileSync('pnpm', ['--silent', 'nx', ...args, '--json'], { encoding: 'utf-8' });
+  return JSON.parse(stdout);
+}

--- a/tools/nx-json.mjs
+++ b/tools/nx-json.mjs
@@ -10,6 +10,8 @@
 import { execFileSync } from 'node:child_process';
 
 export function nxJson(args) {
-  const stdout = execFileSync('pnpm', ['--silent', 'nx', ...args, '--json'], { encoding: 'utf-8' });
+  const stdout = execFileSync('pnpm', ['--silent', 'nx', ...args, '--json'], {
+    encoding: 'utf-8',
+  });
   return JSON.parse(stdout);
 }

--- a/tools/release-changelog.mjs
+++ b/tools/release-changelog.mjs
@@ -1,0 +1,47 @@
+// Generates a per-project changelog entry for every publishable library, using
+// each project's current on-disk version (already bumped by tools/release-version.mjs).
+//
+// `nx release changelog` requires an explicit version when invoked directly, and
+// since projectsRelationship is "independent" each library can be on a different
+// version - so it can't be driven by a single `nx release changelog <version>` call
+// the way a "fixed" release group could. This loops per project instead.
+//
+// Used by the real release workflow (.github/workflows/release.yml), where git
+// actions are enabled. Any CLI args passed to this script (e.g. --git-commit
+// --git-tag --first-release --dry-run) are forwarded as-is to each `nx release
+// changelog` invocation.
+//
+// --projects=<comma/space-separated Nx project names> is handled here, not
+// forwarded (each `nx release changelog` call already gets its own explicit
+// `-p <project>`) - mirrors the `projects` workflow_dispatch input, so a
+// first-release run can target just the new library.
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { nxJson } from './nx-json.mjs';
+
+const rawArgs = process.argv.slice(2);
+const projectsArg = rawArgs.find((arg) => arg.startsWith('--projects='));
+const filter = projectsArg
+  ? projectsArg
+      .slice('--projects='.length)
+      .split(/[\s,]+/)
+      .map((name) => name.trim())
+      .filter(Boolean)
+  : [];
+const extraArgs = rawArgs.filter((arg) => arg !== projectsArg);
+
+const projects = nxJson(['show', 'projects', '--with-target', 'nx-release-publish']).filter(
+  (project) => filter.length === 0 || filter.includes(project),
+);
+
+for (const project of projects) {
+  const { root } = nxJson(['show', 'project', project]);
+  const { version } = JSON.parse(readFileSync(join(root, 'package.json'), 'utf-8'));
+
+  execFileSync(
+    'pnpm',
+    ['nx', 'release', 'changelog', version, '-p', project, '--git-push=false', ...extraArgs],
+    { stdio: 'inherit' },
+  );
+}

--- a/tools/release-changelog.mjs
+++ b/tools/release-changelog.mjs
@@ -31,17 +31,31 @@ const filter = projectsArg
   : [];
 const extraArgs = rawArgs.filter((arg) => arg !== projectsArg);
 
-const projects = nxJson(['show', 'projects', '--with-target', 'nx-release-publish']).filter(
-  (project) => filter.length === 0 || filter.includes(project),
-);
+const projects = nxJson([
+  'show',
+  'projects',
+  '--with-target',
+  'nx-release-publish',
+]).filter((project) => filter.length === 0 || filter.includes(project));
 
 for (const project of projects) {
   const { root } = nxJson(['show', 'project', project]);
-  const { version } = JSON.parse(readFileSync(join(root, 'package.json'), 'utf-8'));
+  const { version } = JSON.parse(
+    readFileSync(join(root, 'package.json'), 'utf-8'),
+  );
 
   execFileSync(
     'pnpm',
-    ['nx', 'release', 'changelog', version, '-p', project, '--git-push=false', ...extraArgs],
+    [
+      'nx',
+      'release',
+      'changelog',
+      version,
+      '-p',
+      project,
+      '--git-push=false',
+      ...extraArgs,
+    ],
     { stdio: 'inherit' },
   );
 }

--- a/tools/release-local-changelog.mjs
+++ b/tools/release-local-changelog.mjs
@@ -1,0 +1,43 @@
+// Generates a per-project changelog entry for every publishable library, using
+// each project's current on-disk version (already bumped by tools/release-version.mjs).
+//
+// `nx release changelog` requires an explicit version when invoked directly, and
+// since projectsRelationship is "independent" each library can be on a different
+// version - so it can't be driven by a single `nx release changelog <version>` call
+// the way a "fixed" release group could. This loops per project instead.
+//
+// `--first-release` is always passed here because `release-local` never creates
+// git tags (git-tag=false), so there is never a previous tag for Nx to diff from.
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const projects = JSON.parse(
+  execFileSync('pnpm', ['nx', 'show', 'projects', '--json', '--with-target', 'nx-release-publish'], {
+    encoding: 'utf-8',
+  }),
+);
+
+for (const project of projects) {
+  const { root } = JSON.parse(
+    execFileSync('pnpm', ['nx', 'show', 'project', project, '--json'], { encoding: 'utf-8' }),
+  );
+  const { version } = JSON.parse(readFileSync(join(root, 'package.json'), 'utf-8'));
+
+  execFileSync(
+    'pnpm',
+    [
+      'nx',
+      'release',
+      'changelog',
+      version,
+      '-p',
+      project,
+      '--first-release',
+      '--git-commit=false',
+      '--git-tag=false',
+      '--git-push=false',
+    ],
+    { stdio: 'inherit' },
+  );
+}

--- a/tools/release-local-changelog.mjs
+++ b/tools/release-local-changelog.mjs
@@ -13,16 +13,24 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 const projects = JSON.parse(
-  execFileSync('pnpm', ['nx', 'show', 'projects', '--json', '--with-target', 'nx-release-publish'], {
-    encoding: 'utf-8',
-  }),
+  execFileSync(
+    'pnpm',
+    ['nx', 'show', 'projects', '--json', '--with-target', 'nx-release-publish'],
+    {
+      encoding: 'utf-8',
+    },
+  ),
 );
 
 for (const project of projects) {
   const { root } = JSON.parse(
-    execFileSync('pnpm', ['nx', 'show', 'project', project, '--json'], { encoding: 'utf-8' }),
+    execFileSync('pnpm', ['nx', 'show', 'project', project, '--json'], {
+      encoding: 'utf-8',
+    }),
   );
-  const { version } = JSON.parse(readFileSync(join(root, 'package.json'), 'utf-8'));
+  const { version } = JSON.parse(
+    readFileSync(join(root, 'package.json'), 'utf-8'),
+  );
 
   execFileSync(
     'pnpm',

--- a/tools/release-local-cleanup.mjs
+++ b/tools/release-local-cleanup.mjs
@@ -1,0 +1,59 @@
+// Discards the local, uncommitted side effects of `release-local`: the version
+// bump in each publishable library's package.json, its CHANGELOG.md entry, and
+// the resulting pnpm-lock.yaml update. Publishing to the local Verdaccio registry
+// is meant purely for testing, so none of this should linger as working-tree noise.
+//
+// Files that already exist in HEAD are restored (index + working tree) from there;
+// files that don't (e.g. a project's first-ever CHANGELOG.md) are unstaged and deleted.
+//
+// Note: `nx release version`/`changelog` run `git add` on the files they touch even
+// with --git-commit=false ("Staging changed files with git"), so a plain
+// `git checkout -- <path>` is a no-op here - it restores the working tree from the
+// (already dirty) index, not from HEAD. `git checkout HEAD -- <path>` is required to
+// actually discard the change. Likewise, checking "is this tracked?" via `git ls-files`
+// would report a staged-but-never-committed new file as tracked, so we check
+// existence in HEAD directly instead.
+import { execFileSync } from 'node:child_process';
+import { existsSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+
+function existsInHead(path) {
+  try {
+    execFileSync('git', ['cat-file', '-e', `HEAD:${path}`], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function restore(path) {
+  if (existsInHead(path)) {
+    execFileSync('git', ['checkout', 'HEAD', '--', path], { stdio: 'inherit' });
+    return;
+  }
+  // Never committed: drop it from the index (if staged) and delete it.
+  try {
+    execFileSync('git', ['reset', '-q', 'HEAD', '--', path], { stdio: 'ignore' });
+  } catch {
+    // Not in the index either - nothing to unstage.
+  }
+  if (existsSync(path)) {
+    rmSync(path, { force: true });
+  }
+}
+
+const projects = JSON.parse(
+  execFileSync('pnpm', ['nx', 'show', 'projects', '--json', '--with-target', 'nx-release-publish'], {
+    encoding: 'utf-8',
+  }),
+);
+
+for (const project of projects) {
+  const { root } = JSON.parse(
+    execFileSync('pnpm', ['nx', 'show', 'project', project, '--json'], { encoding: 'utf-8' }),
+  );
+  restore(join(root, 'package.json'));
+  restore(join(root, 'CHANGELOG.md'));
+}
+
+restore('pnpm-lock.yaml');

--- a/tools/release-local-cleanup.mjs
+++ b/tools/release-local-cleanup.mjs
@@ -19,7 +19,9 @@ import { join } from 'node:path';
 
 function existsInHead(path) {
   try {
-    execFileSync('git', ['cat-file', '-e', `HEAD:${path}`], { stdio: 'ignore' });
+    execFileSync('git', ['cat-file', '-e', `HEAD:${path}`], {
+      stdio: 'ignore',
+    });
     return true;
   } catch {
     return false;
@@ -33,7 +35,9 @@ function restore(path) {
   }
   // Never committed: drop it from the index (if staged) and delete it.
   try {
-    execFileSync('git', ['reset', '-q', 'HEAD', '--', path], { stdio: 'ignore' });
+    execFileSync('git', ['reset', '-q', 'HEAD', '--', path], {
+      stdio: 'ignore',
+    });
   } catch {
     // Not in the index either - nothing to unstage.
   }
@@ -43,14 +47,20 @@ function restore(path) {
 }
 
 const projects = JSON.parse(
-  execFileSync('pnpm', ['nx', 'show', 'projects', '--json', '--with-target', 'nx-release-publish'], {
-    encoding: 'utf-8',
-  }),
+  execFileSync(
+    'pnpm',
+    ['nx', 'show', 'projects', '--json', '--with-target', 'nx-release-publish'],
+    {
+      encoding: 'utf-8',
+    },
+  ),
 );
 
 for (const project of projects) {
   const { root } = JSON.parse(
-    execFileSync('pnpm', ['nx', 'show', 'project', project, '--json'], { encoding: 'utf-8' }),
+    execFileSync('pnpm', ['nx', 'show', 'project', project, '--json'], {
+      encoding: 'utf-8',
+    }),
   );
   restore(join(root, 'package.json'));
   restore(join(root, 'CHANGELOG.md'));

--- a/tools/release-local-unpublish.mjs
+++ b/tools/release-local-unpublish.mjs
@@ -1,0 +1,34 @@
+// npm registries treat published versions as immutable, so republishing the same
+// version (e.g. running `release-local` again without a new commit to bump it) would
+// normally fail. The local Verdaccio registry is throwaway (.verdaccio/config.yml
+// grants unpublish: $all), so we clear each project's about-to-be-published version
+// first. This keeps versions predictable across repeated local test runs - always the
+// same "next" version until a real commit bumps it - so you can always install with
+// e.g. `pnpm add @cdk-x/core --registry=http://localhost:4873` and get the latest
+// local build without needing to know an exact version string.
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const REGISTRY = 'http://localhost:4873';
+
+const projects = JSON.parse(
+  execFileSync('pnpm', ['nx', 'show', 'projects', '--json', '--with-target', 'nx-release-publish'], {
+    encoding: 'utf-8',
+  }),
+);
+
+for (const project of projects) {
+  const { root } = JSON.parse(
+    execFileSync('pnpm', ['nx', 'show', 'project', project, '--json'], { encoding: 'utf-8' }),
+  );
+  const { name, version } = JSON.parse(readFileSync(join(root, 'package.json'), 'utf-8'));
+
+  try {
+    execFileSync('npm', ['unpublish', `${name}@${version}`, '--registry', REGISTRY, '--force'], {
+      stdio: 'inherit',
+    });
+  } catch {
+    // Nothing published at this version yet on the local registry - fine, continue.
+  }
+}

--- a/tools/release-local-unpublish.mjs
+++ b/tools/release-local-unpublish.mjs
@@ -13,21 +13,33 @@ import { join } from 'node:path';
 const REGISTRY = 'http://localhost:4873';
 
 const projects = JSON.parse(
-  execFileSync('pnpm', ['nx', 'show', 'projects', '--json', '--with-target', 'nx-release-publish'], {
-    encoding: 'utf-8',
-  }),
+  execFileSync(
+    'pnpm',
+    ['nx', 'show', 'projects', '--json', '--with-target', 'nx-release-publish'],
+    {
+      encoding: 'utf-8',
+    },
+  ),
 );
 
 for (const project of projects) {
   const { root } = JSON.parse(
-    execFileSync('pnpm', ['nx', 'show', 'project', project, '--json'], { encoding: 'utf-8' }),
+    execFileSync('pnpm', ['nx', 'show', 'project', project, '--json'], {
+      encoding: 'utf-8',
+    }),
   );
-  const { name, version } = JSON.parse(readFileSync(join(root, 'package.json'), 'utf-8'));
+  const { name, version } = JSON.parse(
+    readFileSync(join(root, 'package.json'), 'utf-8'),
+  );
 
   try {
-    execFileSync('npm', ['unpublish', `${name}@${version}`, '--registry', REGISTRY, '--force'], {
-      stdio: 'inherit',
-    });
+    execFileSync(
+      'npm',
+      ['unpublish', `${name}@${version}`, '--registry', REGISTRY, '--force'],
+      {
+        stdio: 'inherit',
+      },
+    );
   } catch {
     // Nothing published at this version yet on the local registry - fine, continue.
   }

--- a/tools/release-version.mjs
+++ b/tools/release-version.mjs
@@ -42,9 +42,12 @@ const filter = projectsArg
 const extraArgs = rawArgs.filter((arg) => arg !== projectsArg);
 const firstRelease = extraArgs.includes('--first-release');
 
-const projects = nxJson(['show', 'projects', '--with-target', 'nx-release-publish']).filter(
-  (project) => filter.length === 0 || filter.includes(project),
-);
+const projects = nxJson([
+  'show',
+  'projects',
+  '--with-target',
+  'nx-release-publish',
+]).filter((project) => filter.length === 0 || filter.includes(project));
 
 for (const project of projects) {
   const config = nxJson(['show', 'project', project]);

--- a/tools/release-version.mjs
+++ b/tools/release-version.mjs
@@ -1,0 +1,62 @@
+// Bumps every publishable project's version, one `nx release version` call per
+// project, because with `projectsRelationship: "independent"` different projects
+// can be in different release phases (alpha/beta/rc/stable - see each project's
+// `release.phase` in its project.json) and therefore need a different `--preid`.
+// A single global `nx release version` invocation can only apply one `--preid`
+// to the whole run, which can't express "core is alpha, some-other-lib is stable"
+// at the same time.
+//
+// Phase -> behaviour:
+//   - "stable" (or no `release.phase` set): no --preid. If the project is
+//     currently on a prerelease version, this is what graduates it to a real
+//     release (conventional commits still drives the bump itself).
+//   - "alpha" | "beta" | "rc": --preid=<phase>, so the computed bump lands as
+//     e.g. 1.1.0-alpha.0, then 1.1.0-alpha.1, etc. Changing the phase value
+//     starts a fresh prerelease train (e.g. 1.1.0-beta.0).
+//
+// --first-release is a special case: conventional-commits bump math doesn't
+// apply to a project's very first release, so an explicit version specifier is
+// used instead of relying on --preid - 1.0.0 for stable, 1.0.0-<phase>.0
+// otherwise (mirrors how a plain first stable release is always forced to
+// exactly 1.0.0 rather than computed on top of whatever placeholder version is
+// on disk).
+//
+// --projects=<comma/space-separated Nx project names> is handled here, not
+// forwarded (each project gets its own explicit `-p <project>` call already) -
+// mirrors the `projects` workflow_dispatch input, so a first-release run can
+// target just the new library. Every other CLI arg (e.g. --git-commit=false
+// --git-tag=false --git-push=false --first-release --dry-run) is forwarded
+// as-is to each `nx release version` invocation.
+import { execFileSync } from 'node:child_process';
+import { nxJson } from './nx-json.mjs';
+
+const rawArgs = process.argv.slice(2);
+const projectsArg = rawArgs.find((arg) => arg.startsWith('--projects='));
+const filter = projectsArg
+  ? projectsArg
+      .slice('--projects='.length)
+      .split(/[\s,]+/)
+      .map((name) => name.trim())
+      .filter(Boolean)
+  : [];
+const extraArgs = rawArgs.filter((arg) => arg !== projectsArg);
+const firstRelease = extraArgs.includes('--first-release');
+
+const projects = nxJson(['show', 'projects', '--with-target', 'nx-release-publish']).filter(
+  (project) => filter.length === 0 || filter.includes(project),
+);
+
+for (const project of projects) {
+  const config = nxJson(['show', 'project', project]);
+  const phase = config.release?.phase ?? 'stable';
+
+  const args = ['release', 'version'];
+  if (firstRelease) {
+    args.push(phase === 'stable' ? '1.0.0' : `1.0.0-${phase}.0`);
+  } else if (phase !== 'stable') {
+    args.push(`--preid=${phase}`);
+  }
+  args.push('-p', project, ...extraArgs);
+
+  execFileSync('pnpm', ['nx', ...args], { stdio: 'inherit' });
+}

--- a/tools/validate-release-phase.mjs
+++ b/tools/validate-release-phase.mjs
@@ -14,7 +14,9 @@ import { nxJson } from './nx-json.mjs';
 
 const [branch, ...rest] = process.argv.slice(2);
 if (!branch) {
-  console.error('Usage: node tools/validate-release-phase.mjs <branch> [--projects=<names>]');
+  console.error(
+    'Usage: node tools/validate-release-phase.mjs <branch> [--projects=<names>]',
+  );
   process.exit(1);
 }
 
@@ -27,9 +29,12 @@ const filter = projectsArg
       .filter(Boolean)
   : [];
 
-const projects = nxJson(['show', 'projects', '--with-target', 'nx-release-publish']).filter(
-  (project) => filter.length === 0 || filter.includes(project),
-);
+const projects = nxJson([
+  'show',
+  'projects',
+  '--with-target',
+  'nx-release-publish',
+]).filter((project) => filter.length === 0 || filter.includes(project));
 
 const violations = [];
 for (const project of projects) {
@@ -37,10 +42,14 @@ for (const project of projects) {
   const phase = config.release?.phase ?? 'stable';
 
   if (branch === 'main' && phase !== 'stable') {
-    violations.push(`${project} is in phase "${phase}" - only "stable" releases are allowed from main.`);
+    violations.push(
+      `${project} is in phase "${phase}" - only "stable" releases are allowed from main.`,
+    );
   }
   if (branch === 'next' && phase === 'stable') {
-    violations.push(`${project} is in phase "stable" - stable releases must be cut from main, not next.`);
+    violations.push(
+      `${project} is in phase "stable" - stable releases must be cut from main, not next.`,
+    );
   }
 }
 

--- a/tools/validate-release-phase.mjs
+++ b/tools/validate-release-phase.mjs
@@ -1,0 +1,55 @@
+// Guards against releasing the wrong kind of version from the wrong branch:
+//   - `main` may only release projects whose `release.phase` (project.json) is
+//     "stable" (or unset, which defaults to "stable").
+//   - `next` may only release projects whose phase is a prerelease phase
+//     (anything other than "stable").
+//
+// Any other branch is allowed to release anything (e.g. manual workflow_dispatch
+// runs from a feature branch for testing) - only `main`/`next` are gated, since
+// those are the two branches release.yml is meant to be dispatched from.
+//
+// Usage: node tools/validate-release-phase.mjs <branch> [--projects=<comma/space-separated names>]
+// Exits non-zero with a clear message if any targeted project violates the rule.
+import { nxJson } from './nx-json.mjs';
+
+const [branch, ...rest] = process.argv.slice(2);
+if (!branch) {
+  console.error('Usage: node tools/validate-release-phase.mjs <branch> [--projects=<names>]');
+  process.exit(1);
+}
+
+const projectsArg = rest.find((arg) => arg.startsWith('--projects='));
+const filter = projectsArg
+  ? projectsArg
+      .slice('--projects='.length)
+      .split(/[\s,]+/)
+      .map((name) => name.trim())
+      .filter(Boolean)
+  : [];
+
+const projects = nxJson(['show', 'projects', '--with-target', 'nx-release-publish']).filter(
+  (project) => filter.length === 0 || filter.includes(project),
+);
+
+const violations = [];
+for (const project of projects) {
+  const config = nxJson(['show', 'project', project]);
+  const phase = config.release?.phase ?? 'stable';
+
+  if (branch === 'main' && phase !== 'stable') {
+    violations.push(`${project} is in phase "${phase}" - only "stable" releases are allowed from main.`);
+  }
+  if (branch === 'next' && phase === 'stable') {
+    violations.push(`${project} is in phase "stable" - stable releases must be cut from main, not next.`);
+  }
+}
+
+if (violations.length > 0) {
+  console.error('Release phase validation failed:');
+  for (const violation of violations) {
+    console.error(`  - ${violation}`);
+  }
+  process.exit(1);
+}
+
+console.log(`Release phase validation passed for branch "${branch}".`);


### PR DESCRIPTION
## Summary
- Wire up `nx release` for independent per-package versioning, conventional commits, and per-project changelogs (no workspace-level changelog/GitHub Releases).
- Add a local Verdaccio dry-run flow (`nx release-local`) to test the full version → changelog → publish pipeline without touching npm or git history.
- Add a manual (`workflow_dispatch`) release workflow publishing to npm/PyPI/Maven/NuGet/Go, with dynamic per-package matrices.
- Introduce a `release.phase` field (alpha/beta/rc/stable) per package in its `project.json`, driving `--preid` on version bumps and the npm dist-tag on publish. A validation script gates the release workflow so `main` can only release `stable` phases and `next` can only release prerelease phases.
- `core` is set to phase `alpha`, bumped to `1.0.0-alpha.0`, and marked `stability: experimental` in its jsii assembly.

## Test plan
- [x] `pnpm nx run-many -t lint test build typecheck` passes
- [x] `nx show project core --json` surfaces the new `release.phase` field
- [x] `node tools/validate-release-phase.mjs main` fails (core is alpha) / `next` passes
- [x] `node tools/list-release-projects.mjs` returns `{name, root, phase}` for core
- [x] Full `nx release-local` run against a local Verdaccio registry: bumped, changelogged, published `@cdk-x/core@1.0.0-alpha.0`, unpublished, and cleaned up the working tree
- [ ] Real publish via `.github/workflows/release.yml` — blocked until GitHub Environments/secrets (`npm-core`, `pypi-@cdk-x/core`, `nuget`, Maven/Go credentials) are provisioned