### PR TITLE
ci(repo): register release workflow for manual dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,335 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      projects:
+        description: 'Comma/space-separated project names to release (e.g. core). Empty = all projects with pending changes.'
+        type: string
+        default: ''
+      first_release:
+        description: "First release for the selected project(s): forces an explicit 1.0.0 (or 1.0.0-<phase>.0) version instead of a conventional-commits bump, and switches npm publish to a classic NPM_TOKEN instead of OIDC Trusted Publisher (which can't be configured on npm before the package exists)"
+        type: boolean
+        default: false
+      dry_run:
+        description: 'Dry run: no git push, no real publish (PUBLIB_DRYRUN=true)'
+        type: boolean
+        default: false
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  version:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      sha: ${{ steps.resolve-sha.outputs.sha }}
+      projects: ${{ steps.affected.outputs.projects }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          filter: tree:0
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: 'pnpm'
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Configure release commit identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Verify branch is releasable
+        run: pnpm nx run-many -t lint test build typecheck
+
+      # `main` may only release "stable"-phase packages, `next` may only release
+      # prerelease-phase (alpha/beta/rc) packages - each package's phase lives in
+      # its project.json under `release.phase`. See tools/validate-release-phase.mjs.
+      - name: Validate release phase matches branch
+        run: >
+          node tools/validate-release-phase.mjs ${{ github.ref_name }}
+          ${{ inputs.projects && format('--projects={0}', inputs.projects) || '' }}
+
+      # Always writes real (uncommitted) files to disk, dry run or not - never
+      # passes nx's own --dry-run here - so the affected check below sees the
+      # same on-disk state either way. Nothing gets committed/tagged/pushed
+      # from this step regardless (that boundary is the next two steps).
+      #
+      # Runs one `nx release version` per project (tools/release-version.mjs)
+      # instead of a single global call, because each project's phase
+      # (alpha/beta/rc/stable) needs its own --preid.
+      - name: Bump versions
+        run: >
+          node tools/release-version.mjs
+          --git-commit=false --git-tag=false --git-push=false
+          ${{ inputs.projects && format('--projects={0}', inputs.projects) || '' }}
+          ${{ inputs.first_release && '--first-release' || '' }}
+
+      # Which projects actually need releasing, including dependents whose
+      # package.json got a dependency-range bump as a side effect of the
+      # above.
+      - name: Determine actually-affected projects
+        id: affected
+        run: echo "projects=$(pnpm --silent nx show projects --affected --json | jq -r 'join(",")')" >> "$GITHUB_OUTPUT"
+
+      - name: Generate changelogs, commit and tag per project
+        run: >
+          node tools/release-changelog.mjs --git-commit --git-tag
+          ${{ steps.affected.outputs.projects && format('--projects={0}', steps.affected.outputs.projects) || '' }}
+          ${{ inputs.first_release && '--first-release' || '' }}
+          ${{ inputs.dry_run && '--dry-run' || '' }}
+
+      - name: Push commits and tags
+        if: ${{ !inputs.dry_run }}
+        run: git push origin HEAD --follow-tags
+
+      - name: Resolve released sha
+        id: resolve-sha
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+  build-jsii:
+    needs: version
+    runs-on: ubuntu-latest
+    outputs:
+      projects: ${{ steps.list-projects.outputs.projects }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.version.outputs.sha }}
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: 'pnpm'
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: '8.x'
+
+      - run: pnpm install --frozen-lockfile
+
+      # needs.version.outputs.projects is every affected project - intersect
+      # with --with-target so only the actual jsii libraries get compiled.
+      - name: Compile and package jsii artifacts for every language
+        run: |
+          projects=$(pnpm --silent nx show projects --json --with-target jsii-package-all ${{ needs.version.outputs.projects && format('-p {0}', needs.version.outputs.projects) || '' }} | jq -r 'join(",")')
+          if [ -n "$projects" ]; then
+            pnpm nx run-many -t jsii-package-all -p "$projects"
+          fi
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: jsii-dist
+          path: packages/*/dist-jsii
+          retention-days: 7
+
+      # Dynamic list of {name, root, phase} for every jsii-publishable project -
+      # lets the publish jobs below fan out per package (and pick the right npm
+      # dist-tag per package's phase) without ever hardcoding a package list here.
+      - name: List release projects
+        id: list-projects
+        run: echo "projects=$(node tools/list-release-projects.mjs '${{ needs.version.outputs.projects }}')" >> "$GITHUB_OUTPUT"
+
+  # Registries authenticated with a static secret: no per-project identity
+  # concern, so one job per language loops over every package in turn.
+  publish:
+    needs: [version, build-jsii]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        lang: [java, go]
+    env:
+      PUBLIB_DRYRUN: ${{ inputs.dry_run }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.version.outputs.sha }}
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: 'pnpm'
+
+      - run: pnpm install --frozen-lockfile
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: jsii-dist
+          path: /tmp/jsii-dist
+
+      - name: Restore per-package dist-jsii from artifact
+        run: |
+          for root in $(echo '${{ needs.build-jsii.outputs.projects }}' | jq -r '.[].root'); do
+            mkdir -p "$root/dist-jsii"
+            cp -r "/tmp/jsii-dist/$(basename "$root")/dist-jsii/." "$root/dist-jsii/"
+          done
+
+      - name: Publish Maven
+        if: matrix.lang == 'java'
+        env:
+          MAVEN_SERVER_ID: central-ossrh
+          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+          MAVEN_GPG_PRIVATE_KEY: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+          MAVEN_GPG_PRIVATE_KEY_PASSPHRASE: ${{ secrets.MAVEN_GPG_PRIVATE_KEY_PASSPHRASE }}
+        run: |
+          for root in $(echo '${{ needs.build-jsii.outputs.projects }}' | jq -r '.[].root'); do
+            pnpm exec publib-maven "$root/dist-jsii/java"
+          done
+
+      - name: Publish Go module mirror
+        if: matrix.lang == 'go'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_GO_MIRROR_TOKEN }}
+          GIT_USER_NAME: github-actions[bot]
+          GIT_USER_EMAIL: github-actions[bot]@users.noreply.github.com
+        run: |
+          # Every package shares the same mirror repo, each landing in its own
+          # subdirectory - the loop must stay sequential (no & backgrounding)
+          # to avoid racing pushes to the same repo.
+          for root in $(echo '${{ needs.build-jsii.outputs.projects }}' | jq -r '.[].root'); do
+            pnpm exec publib-golang "$root/dist-jsii/go"
+          done
+
+  publish-pypi:
+    needs: [version, build-jsii]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        pkg: ${{ fromJson(needs.build-jsii.outputs.projects) }}
+    environment: pypi-${{ matrix.pkg.name }}
+    env:
+      PUBLIB_DRYRUN: ${{ inputs.dry_run }}
+      PYPI_TRUSTED_PUBLISHER: '1'
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.version.outputs.sha }}
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: 'pnpm'
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.x'
+      - run: pnpm install --frozen-lockfile
+      - uses: actions/download-artifact@v8
+        with:
+          name: jsii-dist
+          path: /tmp/jsii-dist
+      - name: Restore dist-jsii from artifact
+        run: |
+          mkdir -p "${{ matrix.pkg.root }}/dist-jsii"
+          cp -r "/tmp/jsii-dist/${{ matrix.pkg.name }}/dist-jsii/." "${{ matrix.pkg.root }}/dist-jsii/"
+      - name: Publish PyPI
+        run: pnpm exec publib-pypi "${{ matrix.pkg.root }}/dist-jsii/python"
+
+  publish-npm:
+    needs: [version, build-jsii]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        pkg: ${{ fromJson(needs.build-jsii.outputs.projects) }}
+    environment: npm-${{ matrix.pkg.name }}
+    env:
+      PUBLIB_DRYRUN: ${{ inputs.dry_run }}
+      # A "stable" package publishes under npm's default "latest" tag. Anything
+      # else (alpha/beta/rc) must publish under its own phase tag so it never
+      # becomes what `npm install <pkg>` resolves to - see matrix.pkg.phase,
+      # sourced from each project's release.phase in project.json.
+      NPM_DIST_TAG: ${{ matrix.pkg.phase != 'stable' && matrix.pkg.phase || '' }}
+      NPM_TRUSTED_PUBLISHER: ${{ !inputs.first_release && '1' || '' }}
+      NPM_TOKEN: ${{ inputs.first_release && secrets.NPM_TOKEN || '' }}
+      NPM_ACCESS_LEVEL: public
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.version.outputs.sha }}
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: 'pnpm'
+      # npm Trusted Publisher requires npm CLI >= 11.5.1; the bundled npm may be older.
+      - run: npm install -g npm@latest
+      - run: pnpm install --frozen-lockfile
+      - uses: actions/download-artifact@v8
+        with:
+          name: jsii-dist
+          path: /tmp/jsii-dist
+      - name: Restore dist-jsii from artifact
+        run: |
+          mkdir -p "${{ matrix.pkg.root }}/dist-jsii"
+          cp -r "/tmp/jsii-dist/${{ matrix.pkg.name }}/dist-jsii/." "${{ matrix.pkg.root }}/dist-jsii/"
+      - name: Publish npm
+        run: pnpm exec publib-npm "${{ matrix.pkg.root }}/dist-jsii/js"
+
+  publish-nuget:
+    needs: [version, build-jsii]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      PUBLIB_DRYRUN: ${{ inputs.dry_run }}
+      NUGET_TRUSTED_PUBLISHER: '1'
+      NUGET_USERNAME: ${{ secrets.NUGET_USERNAME }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.version.outputs.sha }}
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: 'pnpm'
+      - uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: '8.x'
+      - run: pnpm install --frozen-lockfile
+      - uses: actions/download-artifact@v8
+        with:
+          name: jsii-dist
+          path: /tmp/jsii-dist
+      - name: Restore per-package dist-jsii from artifact
+        run: |
+          for root in $(echo '${{ needs.build-jsii.outputs.projects }}' | jq -r '.[].root'); do
+            mkdir -p "$root/dist-jsii"
+            cp -r "/tmp/jsii-dist/$(basename "$root")/dist-jsii/." "$root/dist-jsii/"
+          done
+      - name: Publish NuGet
+        run: |
+          for root in $(echo '${{ needs.build-jsii.outputs.projects }}' | jq -r '.[].root'); do
+            pnpm exec publib-nuget "$root/dist-jsii/dotnet"
+          done


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/release.yml` (copied as-is from `next`) to `main`, without pulling in any other `next` changes.
- Registers the `workflow_dispatch` trigger on the default branch so GitHub allows manually dispatching it — required the first time, since a workflow must exist on the default branch to appear as runnable, regardless of which branch/ref it's later dispatched against.

## Why
`release.yml` currently only exists on `next` (redesign v1 in progress, not ready to merge into `main` yet), so it never shows up under Actions and can't be run. Once registered here, runs can target `next` (or any branch) via "Use workflow from" / `gh workflow run release.yml --ref next`, executing that branch's version of the file.

## Test plan
- [ ] Confirm "Release" appears under the Actions tab after merge
- [ ] `gh workflow run release.yml --ref next -f dry_run=true` and verify the `version` job checks out `next` and applies the `next` → prerelease phase validation